### PR TITLE
Implement handling of --ignore-existing

### DIFF
--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -49,15 +49,8 @@ type Config struct {
 	// Adjust verbosity.
 	Verbose int `short:"v" type:"counter" help:"Increase verbosity; can be provided multiple times."`
 
-	// TODO: fail if publish contains any files.
-	// Note: the story with this is that some tools use an approach like this to implement
-	// a "remote mkdir":
-	// mkdir -p root/empty-dir
-	// rsync --ignore-existing root host:/dest/some/dir/which/should/be/created
-	// Since directories don't actually exist in exodus, that should be a no-op which
-	// successfully does nothing.  But any *other* attempted usage of --ignore-existing
-	// should be an error (we don't have the capability to skip content which is
-	// already present).
+	// Mostly ignored, but causes a failure if publish contains any files.
+	// See comments where the argument is checked for the explanation why.
 	IgnoreExisting bool `hidden:"1"`
 
 	// TODO: --dry-run, -n

--- a/internal/cmd/cmd_sync_ignore_existing_test.go
+++ b/internal/cmd/cmd_sync_ignore_existing_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/release-engineering/exodus-rsync/internal/gw"
+)
+
+func TestMainSyncIgnoreExisting(t *testing.T) {
+	SetConfig(t, CONFIG)
+
+	logs := CaptureLogger(t)
+
+	ctrl := MockController(t)
+
+	mockGw := gw.NewMockInterface(ctrl)
+	ext.gw = mockGw
+
+	client := FakeClient{blobs: make(map[string]string)}
+
+	t.Run("ignore-existing OK if no files", func(t *testing.T) {
+		os.Mkdir("nofiles", 0755)
+		os.Mkdir("nofiles/subdir", 0755)
+
+		args := []string{"rsync", "--ignore-existing", "nofiles", "exodus:/some/target"}
+
+		mockGw.EXPECT().NewClient(EnvMatcher{"best-env"}).Return(&client, nil)
+		got := Main(args)
+
+		// It should succeed, though not actually do anything.
+		if got != 0 {
+			t.Errorf("unexpectedly failed with code = %v", got)
+		}
+	})
+
+	t.Run("ignore-existing fails if files exist", func(t *testing.T) {
+		os.Mkdir("files", 0755)
+		os.WriteFile("files/file1", []byte("hello"), 0644)
+
+		args := []string{"rsync", "--ignore-existing", "files", "exodus:/some/target"}
+
+		mockGw.EXPECT().NewClient(EnvMatcher{"best-env"}).Return(&client, nil)
+		got := Main(args)
+
+		// It should fail
+		if got != 73 {
+			t.Errorf("got unexpected exit code = %v", got)
+		}
+
+		// It should tell us why
+		entry := FindEntry(logs, "can't read files for sync")
+		if entry == nil {
+			t.Error("missing expected log message")
+		}
+
+		err := fmt.Sprint(entry.Fields["error"])
+		if !strings.Contains(err, "--ignore-existing is not supported") {
+			t.Error("unexpected error message", err)
+		}
+	})
+
+}


### PR DESCRIPTION
This argument should produce a fatal error if the src tree is not
empty, because we can't support the requested behavior.