### PR TITLE
Ensure presence/absence of trailing / is rsync-compatible

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/release-engineering/exodus-rsync/internal/args"
@@ -27,10 +28,17 @@ var ext = struct {
 }
 
 func webURI(srcPath string, srcTree string, destTree string) string {
-	// TODO: handle the different behaviors when / is or is not given for src/dest
 	cleanSrcPath := path.Clean(srcPath)
 	cleanSrcTree := path.Clean(srcTree)
 	relPath := strings.TrimPrefix(cleanSrcPath, cleanSrcTree+"/")
+
+	// Presence of trailing slash changes the behavior when assembling
+	// destination paths, see "man rsync" and search for "trailing".
+	if srcTree != "." && !strings.HasSuffix(srcTree, "/") {
+		srcBase := filepath.Base(srcTree)
+		return path.Join(destTree, srcBase, relPath)
+	}
+
 	return path.Join(destTree, relPath)
 }
 

--- a/internal/cmd/cmd_sync_test.go
+++ b/internal/cmd/cmd_sync_test.go
@@ -108,7 +108,7 @@ func TestMainTypicalSync(t *testing.T) {
 
 	args := []string{
 		"rsync",
-		srcPath,
+		srcPath + "/",
 		"exodus:/some/target",
 	}
 
@@ -187,7 +187,7 @@ func TestMainSyncFollowsLinks(t *testing.T) {
 	args := []string{
 		"rsync",
 		"-vvv",
-		srcPath,
+		srcPath + "/",
 		"exodus:/dest",
 	}
 
@@ -223,6 +223,72 @@ func TestMainSyncFollowsLinks(t *testing.T) {
 		"/dest/subdir2/dir-link/regular-file": "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
 		"/dest/subdir2/dir-link/rand1":        "57921e8a0929eaff5003cc9dd528c3421296055a4de2ba72429dc7f41bfa8411",
 		"/dest/subdir2/dir-link/rand2":        "f3a5340ae2a400803b8150f455ad285d173cbdcf62c8e9a214b30f467f45b310",
+	}
+
+	if !reflect.DeepEqual(itemMap, expectedItems) {
+		t.Error("did not publish expected items, published:", itemMap)
+	}
+
+	// It should have committed the publish (once)
+	if p.committed != 1 {
+		t.Error("expected to commit publish (once), instead p.committed ==", p.committed)
+	}
+}
+
+// When src tree has no trailing slash, the basename is repeated as a directory
+// name on the destination.
+func TestMainSyncNoSlash(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	SetConfig(t, CONFIG)
+	ctrl := MockController(t)
+
+	mockGw := gw.NewMockInterface(ctrl)
+	ext.gw = mockGw
+
+	client := FakeClient{blobs: make(map[string]string)}
+	mockGw.EXPECT().NewClient(EnvMatcher{"best-env"}).Return(&client, nil)
+
+	srcPath := path.Clean(wd + "/../../test/data/srctrees/just-files")
+
+	args := []string{
+		"rsync",
+		"-vvv",
+		srcPath,
+		"exodus:/dest",
+	}
+
+	got := Main(args)
+
+	// It should complete successfully.
+	if got != 0 {
+		t.Error("returned incorrect exit code", got)
+	}
+
+	// It should have created one publish.
+	if len(client.publishes) != 1 {
+		t.Error("expected to create 1 publish, instead created", len(client.publishes))
+	}
+
+	p := client.publishes[0]
+
+	// Build up a URI => Key mapping of what was published
+	itemMap := make(map[string]string)
+	for _, item := range p.items {
+		if _, ok := itemMap[item.WebURI]; ok {
+			t.Error("tried to publish this URI more than once:", item.WebURI)
+		}
+		itemMap[item.WebURI] = item.ObjectKey
+	}
+
+	// It should have been exactly this
+	expectedItems := map[string]string{
+		"/dest/just-files/hello-copy-one":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+		"/dest/just-files/hello-copy-two":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+		"/dest/just-files/subdir/some-binary": "c66f610d98b2c9fe0175a3e99ba64d7fc7de45046515ff325be56329a9347dd6",
 	}
 
 	if !reflect.DeepEqual(itemMap, expectedItems) {


### PR DESCRIPTION
To be compatible with rsync, if and only if SRC does not end with
/, we will join the last component of the path name onto the
destination.