### PR TITLE
Fix all items passed in single request to exodus-gw

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ The configuration file is written in YAML. The available config keys
 are documented in the example below:
 
 ```yaml
+###############################################################################
+# exodus-gw environment settings
+###############################################################################
+#
 # X509 PEM-format certificate and key for authentication to exodus-gw.
 # Environment variables may be used with these paths.
 gwcert: $HOME/certs/$USER.crt
@@ -71,7 +75,9 @@ gwurl: https://exodus-gw.example.com
 # this environment, such as `prod-blob-uploader`, `prod-publisher`.
 gwenv: prod
 
-# Configuration per target prefix.
+###############################################################################
+# Environment configuration
+###############################################################################
 #
 # When exodus-rsync is run as 'rsync' it will inspect the target
 # user@host component of the command-line.
@@ -100,6 +106,23 @@ environments:
   # for example, to use a different exodus-gw service & environment:
   gwurl: https://other-exodus-gw.example.com/
   gwenv: stage
+
+###############################################################################
+# Tuning
+###############################################################################
+#
+# The following fields, all optional, may affect the performance of
+# exodus-rsync.
+#
+# They are listed here along with their default values.
+
+# When awaiting an exodus-gw publish task, how long (in milliseconds) should
+# we wait between each poll of the task status.
+gwpollinterval: 5000
+
+# When adding items onto an exodus-gw publish, what is the maximum number of
+# items we'll include in a single HTTP request.
+gwbatchsize: 10000
 ```
 
 In order to publish to exodus CDN it is necessary to configure all of the

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -36,6 +36,9 @@ type Config interface {
 
 	// How often to poll for task updates, in milliseconds.
 	GwPollInterval() int
+
+	// Max number of items to include in a single HTTP request to exodus-gw.
+	GwBatchSize() int
 }
 
 // EnvironmentConfig provides configuration specific to one environment.

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -31,6 +31,7 @@ gwenv: global-env
 gwurl: https://exodus-gw.example.com
 gwcert: global-cert
 gwkey: global-key
+gwbatchsize: 100
 
 environments:
 - prefix: dest
@@ -90,6 +91,7 @@ environments:
 	// For values which are NOT overridden, they should be equal to global.
 	assertEqual("env gwurl", env.GwURL(), cfg.GwURL())
 	assertEqual("env gwcert", env.GwCert(), cfg.GwCert())
+	assertEqual("env gwbatchsize", env.GwBatchSize(), cfg.GwBatchSize())
 }
 
 func TestDefaultsFromParent(t *testing.T) {

--- a/internal/conf/load.go
+++ b/internal/conf/load.go
@@ -27,7 +27,10 @@ func loadFromPath(path string) (*globalConfig, error) {
 	}
 	defer file.Close()
 
-	defaults := sharedConfig{GwPollIntervalRaw: 5000}
+	defaults := sharedConfig{
+		GwPollIntervalRaw: 5000,
+		GwBatchSizeRaw:    10000,
+	}
 
 	dec := yaml.NewDecoder(file)
 	out := &globalConfig{}

--- a/internal/conf/mock.go
+++ b/internal/conf/mock.go
@@ -73,6 +73,20 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 	return m.recorder
 }
 
+// GwBatchSize mocks base method.
+func (m *MockConfig) GwBatchSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwBatchSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwBatchSize indicates an expected call of GwBatchSize.
+func (mr *MockConfigMockRecorder) GwBatchSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwBatchSize", reflect.TypeOf((*MockConfig)(nil).GwBatchSize))
+}
+
 // GwCert mocks base method.
 func (m *MockConfig) GwCert() string {
 	m.ctrl.T.Helper()
@@ -164,6 +178,20 @@ func NewMockEnvironmentConfig(ctrl *gomock.Controller) *MockEnvironmentConfig {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEnvironmentConfig) EXPECT() *MockEnvironmentConfigMockRecorder {
 	return m.recorder
+}
+
+// GwBatchSize mocks base method.
+func (m *MockEnvironmentConfig) GwBatchSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwBatchSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwBatchSize indicates an expected call of GwBatchSize.
+func (mr *MockEnvironmentConfigMockRecorder) GwBatchSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwBatchSize", reflect.TypeOf((*MockEnvironmentConfig)(nil).GwBatchSize))
 }
 
 // GwCert mocks base method.
@@ -285,6 +313,20 @@ func (m *MockGlobalConfig) EnvironmentForDest(arg0 context.Context, arg1 string)
 func (mr *MockGlobalConfigMockRecorder) EnvironmentForDest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentForDest", reflect.TypeOf((*MockGlobalConfig)(nil).EnvironmentForDest), arg0, arg1)
+}
+
+// GwBatchSize mocks base method.
+func (m *MockGlobalConfig) GwBatchSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwBatchSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwBatchSize indicates an expected call of GwBatchSize.
+func (mr *MockGlobalConfigMockRecorder) GwBatchSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwBatchSize", reflect.TypeOf((*MockGlobalConfig)(nil).GwBatchSize))
 }
 
 // GwCert mocks base method.

--- a/internal/conf/structs.go
+++ b/internal/conf/structs.go
@@ -6,6 +6,7 @@ type sharedConfig struct {
 	GwKeyRaw          string `yaml:"gwkey"`
 	GwURLRaw          string `yaml:"gwurl"`
 	GwPollIntervalRaw int    `yaml:"gwpollinterval"`
+	GwBatchSizeRaw    int    `yaml:"gwbatchsize"`
 }
 
 type environment struct {
@@ -27,24 +28,24 @@ func (g *globalConfig) GwCert() string {
 	return g.GwCertRaw
 }
 
-// Path to private key used to authenticate with exodus-gw.
 func (g *globalConfig) GwKey() string {
 	return g.GwKeyRaw
 }
 
-// Base URL of exodus-gw service in use.
 func (g *globalConfig) GwURL() string {
 	return g.GwURLRaw
 }
 
-// exodus-gw environment in use (e.g. "prod").
 func (g *globalConfig) GwEnv() string {
 	return g.GwEnvRaw
 }
 
-// How often to poll for task updates, in milliseconds.
 func (g *globalConfig) GwPollInterval() int {
 	return g.GwPollIntervalRaw
+}
+
+func (g *globalConfig) GwBatchSize() int {
+	return g.GwBatchSizeRaw
 }
 
 func nonEmptyString(a, b string) string {
@@ -79,6 +80,10 @@ func (e *environment) GwEnv() string {
 
 func (e *environment) GwPollInterval() int {
 	return nonEmptyInt(e.GwPollIntervalRaw, e.parent.GwPollIntervalRaw)
+}
+
+func (e *environment) GwBatchSize() int {
+	return nonEmptyInt(e.GwBatchSizeRaw, e.parent.GwBatchSizeRaw)
 }
 
 func (e *environment) Prefix() string {

--- a/internal/gw/client_publish_errors_test.go
+++ b/internal/gw/client_publish_errors_test.go
@@ -117,6 +117,27 @@ func TestClientPublishErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("HTTP error during AddItems", func(t *testing.T) {
+		publish := publish{client: clientIface.(*client)}
+		publish.raw.Links = make(map[string]string)
+		publish.raw.Links["self"] = "/publish/1234"
+
+		gw.nextHTTPResponse = &http.Response{
+			Status:     "418 I'm a teapot",
+			StatusCode: 418,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+
+		err := publish.AddItems(ctx, []ItemInput{{"/some/uri", "abc123"}})
+
+		if err == nil {
+			t.Error("Unexpectedly failed to return an error")
+		}
+		if !strings.Contains(err.Error(), "I'm a teapot") {
+			t.Errorf("Did not get expected error, got: %v", err)
+		}
+	})
+
 	t.Run("commit request fails", func(t *testing.T) {
 		publish := publish{client: clientIface.(*client)}
 

--- a/internal/gw/helpers_test.go
+++ b/internal/gw/helpers_test.go
@@ -35,6 +35,7 @@ func testConfig(t *testing.T) conf.Config {
 	cfg.EXPECT().GwURL().AnyTimes().Return("https://exodus-gw.example.com")
 	cfg.EXPECT().GwPollInterval().AnyTimes().Return(1)
 	cfg.EXPECT().GwEnv().AnyTimes().Return("env")
+	cfg.EXPECT().GwBatchSize().AnyTimes().Return(3)
 
 	return cfg
 }


### PR DESCRIPTION
We might be dealing with up to 500,000 items and this is probably
too much for a single request. Batch the requests, using a
configurable batch size.