### PR TITLE
Fix likely race in reading rsync output

### DIFF
--- a/internal/cmd/mixed.go
+++ b/internal/cmd/mixed.go
@@ -128,6 +128,7 @@ func doRsyncCommand(ctx context.Context, cmd *exec.Cmd) int {
 
 	go piper(outScanner, entry.Info)
 	go piper(errScanner, entry.Warn)
+	wg.Wait()
 
 	err = cmd.Wait()
 	if err != nil {


### PR DESCRIPTION
Wait() was never called on the WaitGroup here.
It seems this could potentially result in output from rsync not
being sent to the logger before this function returned.