### PR TITLE
Implement "joined publish" mode

### DIFF
--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -41,6 +41,8 @@ type IgnoredConfig struct {
 // and there are no short flags.
 type ExodusConfig struct {
 	Conf string `help:"Force usage of this configuration file."`
+
+	Publish string `help:"ID of existing exodus-gw publish to."`
 }
 
 // Config contains the subset of arguments which are returned by the parser and

--- a/internal/gw/client.go
+++ b/internal/gw/client.go
@@ -187,6 +187,7 @@ func (impl) NewClient(_ context.Context, cfg conf.Config) (Client, error) {
 
 			Region:      aws.String("us-east-1"),
 			Credentials: credentials.AnonymousCredentials,
+			HTTPClient:  out.httpClient,
 		},
 	})
 	if err != nil {

--- a/internal/gw/gw.go
+++ b/internal/gw/gw.go
@@ -50,6 +50,13 @@ type Client interface {
 
 	// NewPublish creates and returns a new publish object within exodus-gw.
 	NewPublish(context.Context) (Publish, error)
+
+	// GetPublish returns a handle to an existing publish object within exodus-gw.
+	//
+	// This function never fails, but it is not guaranteed that the publish object
+	// is valid. If an invalid publish ID is given, an error will occur the next
+	// time any write operation is attempted on the publish.
+	GetPublish(string) Publish
 }
 
 // Publish represents a publish object in exodus-gw.

--- a/internal/gw/mock.go
+++ b/internal/gw/mock.go
@@ -103,6 +103,20 @@ func (mr *MockClientMockRecorder) EnsureUploaded(ctx, items, onUploaded, onPrese
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureUploaded", reflect.TypeOf((*MockClient)(nil).EnsureUploaded), ctx, items, onUploaded, onPresent)
 }
 
+// GetPublish mocks base method.
+func (m *MockClient) GetPublish(arg0 string) Publish {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublish", arg0)
+	ret0, _ := ret[0].(Publish)
+	return ret0
+}
+
+// GetPublish indicates an expected call of GetPublish.
+func (mr *MockClientMockRecorder) GetPublish(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublish", reflect.TypeOf((*MockClient)(nil).GetPublish), arg0)
+}
+
 // NewPublish mocks base method.
 func (m *MockClient) NewPublish(arg0 context.Context) (Publish, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
In this mode, we attach to an existing publish object in exodus-gw
rather than creating one, thus enabling atomic semantics covering
multiple exodus-rsync invocations.