### PR TITLE
Implement proper lookup of rsync from PATH

### DIFF
--- a/internal/rsync/lookup_test.go
+++ b/internal/rsync/lookup_test.go
@@ -1,0 +1,126 @@
+package rsync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/release-engineering/exodus-rsync/internal/args"
+	"github.com/release-engineering/exodus-rsync/internal/conf"
+	"github.com/release-engineering/exodus-rsync/internal/log"
+)
+
+func setPath(t *testing.T, value string) {
+	oldPath := os.Getenv("PATH")
+
+	t.Cleanup(func() {
+		os.Setenv("PATH", oldPath)
+	})
+	err := os.Setenv("PATH", value)
+	if err != nil {
+		t.Fatalf("could not set PATH, err = %v", err)
+	}
+}
+
+// If an rsync command can't be located, /usr/bin/rsync is used
+// as fallback.
+func TestCommandFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conf := conf.NewMockConfig(ctrl)
+
+	// No PATH at all means no rsync in PATH
+	setPath(t, "")
+
+	ctx := log.NewContext(context.Background(), log.Package.NewLogger(args.Config{}))
+
+	cmd := Package.Command(ctx, conf, args.Config{})
+
+	if cmd.Path != "/usr/bin/rsync" {
+		t.Errorf("command returned unexpected path %v", cmd.Path)
+	}
+}
+
+func TestCommandAvoidSelf(t *testing.T) {
+	oldArg0 := os.Args[0]
+	defer func() {
+		os.Args[0] = oldArg0
+	}()
+
+	tempDir := t.TempDir()
+
+	// Simulate that we are installed as 'rsync' in the tempdir
+	self := tempDir + "/rsync"
+	err := os.WriteFile(self, []byte("#!/bin/sh\necho hi\n"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Args[0] = self
+
+	// Add dir containing self to path *and also* test/bin, which contains
+	// the "real" rsync in the context of this test
+	setPath(t, tempDir+":../../test/bin")
+
+	// Sanity check: naive lookup of rsync should find self
+	foundRsync, err := exec.LookPath("rsync")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if foundRsync != self {
+		t.Fatalf("sanity check of test setup failed, lookup of rsync returned %v", foundRsync)
+	}
+
+	ctrl := gomock.NewController(t)
+	conf := conf.NewMockConfig(ctrl)
+	ctx := log.NewContext(context.Background(), log.Package.NewLogger(args.Config{}))
+
+	cmd := Package.Command(ctx, conf, args.Config{})
+
+	// Rather than looking up ourselves as a plain LookPath did, it should be smart
+	// enough to remove self from path and find the "real" rsync
+	if cmd.Path != "../../test/bin/rsync" {
+		t.Errorf("command returned unexpected path %v", cmd.Path)
+	}
+}
+
+func TestPanic2ErrWithError(t *testing.T) {
+	var err error
+
+	func() {
+		defer panic2err(&err)
+		panic(fmt.Errorf("simulated error"))
+	}()
+
+	// It should put the error into the pointer.
+	if err.Error() != "simulated error" {
+		t.Errorf("did not get expected error, got %v", err)
+	}
+}
+
+func TestPanic2ErrWithOther(t *testing.T) {
+	var err error
+	var recovered interface{}
+
+	func() {
+		defer func() {
+			recovered = recover()
+		}()
+
+		func() {
+			defer panic2err(&err)
+			panic("whatever")
+		}()
+	}()
+
+	// It should not put anything in err, since it wasn't an error.
+	if err != nil {
+		t.Errorf("unexpectedly got error %v", err)
+	}
+
+	// It should propagate whatever was originally panicked.
+	if recovered.(string) != "whatever" {
+		t.Errorf("unexpected value from recover: %v", recovered)
+	}
+}

--- a/internal/rsync/path.go
+++ b/internal/rsync/path.go
@@ -1,0 +1,90 @@
+package rsync
+
+import (
+	"context"
+	"os"
+	exec "os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/release-engineering/exodus-rsync/internal/log"
+)
+
+// Returns path to current exodus-rsync executable.
+func lookupSelf() string {
+	path, err := exec.LookPath(os.Args[0])
+	maybePanic(err)
+	return path
+}
+
+func resolveLinks(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	maybePanic(err)
+	return resolved
+}
+
+func lookupAnyRsync() string {
+	rsync, err := exec.LookPath("rsync")
+	maybePanic(err)
+	return rsync
+}
+
+func panic2err(err *error) {
+	if panicked := recover(); panicked != nil {
+		pErr, haveErr := panicked.(error)
+		if haveErr {
+			// panicked with error, return it
+			*err = pErr
+		} else {
+			// panicked with something else, re-panic
+			panic(panicked)
+		}
+	}
+}
+
+func maybePanic(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func pathWithoutDir(path string, remove string) string {
+	out := path
+	out = strings.ReplaceAll(out, ":"+remove+":", "")
+	out = strings.TrimPrefix(out, remove+":")
+	out = strings.TrimSuffix(out, ":"+remove)
+	return out
+}
+
+func lookupTrueRsync(ctx context.Context) (rsync string, outerr error) {
+	defer panic2err(&outerr)
+
+	logger := log.FromContext(ctx)
+
+	self := lookupSelf()
+	rsync = lookupAnyRsync()
+
+	logger.F("self", self, "rsync", rsync).Debug("Looked up paths")
+
+	resolvedSelf := resolveLinks(self)
+	resolvedRsync := resolveLinks(rsync)
+
+	logger.F("self", resolvedSelf, "rsync", resolvedRsync).Debug("Resolved paths")
+
+	if resolvedSelf == resolvedRsync {
+		// Since we found ourselves, adjust PATH and try one more time.
+		oldPath := os.Getenv("PATH")
+		defer func() {
+			maybePanic(os.Setenv("PATH", oldPath))
+		}()
+
+		maybePanic(os.Setenv("PATH", pathWithoutDir(oldPath, filepath.Dir(self))))
+
+		rsync = lookupAnyRsync()
+
+		logger.F("rsync", rsync, "PATH", os.Getenv("PATH")).Debug(
+			"Resolved with adjusted PATH")
+	}
+
+	return
+}

--- a/test/bin/rsync
+++ b/test/bin/rsync
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Fake rsync to put into PATH during some tests.
+EXITCODE=${RSYNC_EXITCODE:-0}
+
+echo rsync: "$@"
+exit $EXITCODE


### PR DESCRIPTION
Allows exodus-rsync to be installed as "rsync" with the real rsync
found later in PATH.