### PR TITLE
Fix setting of version within github builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        # we don't want a shallow clone because we want to use "git describe"
+        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v2


### PR DESCRIPTION
We can't use a shallow clone because that will break "git describe",
which we use to set a version string.