### PR TITLE
Tweak handling of -v argument to be more rsync-like

### DIFF
--- a/internal/cmd/cmd_bad_conf_test.go
+++ b/internal/cmd/cmd_bad_conf_test.go
@@ -28,7 +28,7 @@ environments:
 		t.Run(tt.name, func(t *testing.T) {
 			SetConfig(t, tt.conf)
 
-			args := []string{"exodus-rsync", "-vvv", "src", "dest"}
+			args := []string{"exodus-rsync", "-v", "src", "dest"}
 
 			if got := Main(args); got != 23 {
 				t.Error("unexpected exit code", got)

--- a/internal/cmd/mixed_fail_test.go
+++ b/internal/cmd/mixed_fail_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apex/log"
 	"github.com/golang/mock/gomock"
 	"github.com/release-engineering/exodus-rsync/internal/args"
 	"github.com/release-engineering/exodus-rsync/internal/conf"
@@ -114,8 +115,16 @@ func TestRsyncFailsFirst(t *testing.T) {
 		t.Error("missing exodus cancel log")
 	}
 
+	// Filter out debug messages
+	entries := make([]*log.Entry, 0)
+	for _, entry := range logs.Entries {
+		if entry.Level >= log.InfoLevel {
+			entries = append(entries, entry)
+		}
+	}
+
 	// Very last message should explain that it was the rsync publish which failed
-	last := logs.Entries[len(logs.Entries)-1]
+	last := entries[len(entries)-1]
 	if last.Message != "Publish via rsync failed" {
 		t.Errorf("unexpected final message: %v", last.Message)
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/apex/log"
 	apexLog "github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/apex/log/handlers/level"
@@ -100,12 +99,17 @@ func (l *Logger) F(v ...interface{}) *apexLog.Entry {
 func (impl) NewLogger(args args.Config) *Logger {
 	logger := Logger{}
 
-	logger.Handler = cli.New(os.Stdout)
-	logger.Level = log.InfoLevel
-	if args.Verbose >= 1 {
-		// TODO: think we need more loggers.
-		logger.Level = log.DebugLevel
+	cliLevel := WarnLevel
+	if args.Verbose == 1 {
+		cliLevel = InfoLevel
+	} else if args.Verbose >= 2 {
+		cliLevel = DebugLevel
 	}
+
+	logger.Handler = level.New(
+		cli.New(os.Stdout),
+		cliLevel,
+	)
 
 	return &logger
 }


### PR DESCRIPTION
default: warnings & errors only.
     -v: one message per write.
    -vv: also enable debug messages.
   -vvv: also enable debug messages from libraries (TODO)