### PR TITLE
Revise release workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,12 +29,3 @@ jobs:
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: coverage.out
-
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          exodus-rsync
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,10 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        # we don't want a shallow clone because we want to use "git describe"
+        fetch-depth: 0
 
     - name: Get version from changelog
       run: sed -r -n -e '/^## [0-9.]+/ { s|^## ([0-9.]+).*|::set-output name=version::\1|p; q }' CHANGELOG.md
       id: get_version
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Compile
+      run: make BUILDVERSION=v${{ steps.get_version.outputs.version }}
 
     - name: Ensure tag exists
       id: tag_version
@@ -25,3 +36,12 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         custom_tag: ${{ steps.get_version.outputs.version }}
         create_annotated_tag: true
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          exodus-rsync
+        tag_name: v${{ steps.get_version.outputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ default: exodus-rsync
 # since a bare failing "test -z" might be undecipherable to some
 fmt-cmd = if ! test -z $$($(1) | tee /dev/stderr); then echo $(2); exit 3; fi
 
-BUILDFLAGS := -ldflags "-X github.com/release-engineering/exodus-rsync/internal/cmd.version=$$(git describe HEAD)"
+BUILDVERSION := $$(git describe HEAD)
+BUILDFLAGS := -ldflags "-X github.com/release-engineering/exodus-rsync/internal/cmd.version=$(BUILDVERSION)"
 
 # Build the main binary for this project.
 exodus-rsync: generate


### PR DESCRIPTION
The previous setup didn't work properly because one github
action is not allowed to trigger another. Therefore, tagging and
releasing can't belong to different workflows.

Revise it to put them in the same workflow. It does unfortunately
mean some duplication between the test and release workflows.