### PR TITLE
Fix panic in dry-run mode when missing cert/key [RHELDST-5408]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- n/a
+- Fix: panic in dry-run mode when missing cert/key.
 
 ## 1.0.0 - 2021-03-11
 

--- a/internal/gw/client_dryrun_test.go
+++ b/internal/gw/client_dryrun_test.go
@@ -2,12 +2,32 @@ package gw
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+
 	"github.com/release-engineering/exodus-rsync/internal/args"
+	"github.com/release-engineering/exodus-rsync/internal/conf"
 	"github.com/release-engineering/exodus-rsync/internal/log"
 	"github.com/release-engineering/exodus-rsync/internal/walk"
 )
+
+func TestNewDryRunClientCertError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cfg := conf.NewMockConfig(ctrl)
+
+	cfg.EXPECT().GwCert().Return("cert-does-not-exist")
+	cfg.EXPECT().GwKey().Return("key-does-not-exist")
+
+	_, err := Package.NewDryRunClient(context.Background(), cfg)
+
+	// Should have given us this error
+	if !strings.Contains(fmt.Sprint(err), "can't load cert/key") {
+		t.Error("did not get expected error, err =", err)
+	}
+}
 
 func TestDryRunUpload(t *testing.T) {
 	ctx := context.Background()

--- a/internal/gw/dryrun.go
+++ b/internal/gw/dryrun.go
@@ -10,6 +10,10 @@ type dryRunPublish struct{}
 
 func (i impl) NewDryRunClient(ctx context.Context, cfg conf.Config) (Client, error) {
 	clientIface, err := i.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	clientIface.(*client).dryRun = true
 	return clientIface, err
 }


### PR DESCRIPTION
This commit fixes a bug wherein exodus-rsync, when ran without cert/key
and dry-run enabled, would panic rather than failing gracefully.