### PR TITLE
Show error responses from exodus-gw [RHELDST-5411]

### DIFF
--- a/internal/gw/client_publish_errors_test.go
+++ b/internal/gw/client_publish_errors_test.go
@@ -123,9 +123,11 @@ func TestClientPublishErrors(t *testing.T) {
 		publish.raw.Links["self"] = "/publish/1234"
 
 		gw.nextHTTPResponse = &http.Response{
-			Status:     "418 I'm a teapot",
-			StatusCode: 418,
-			Body:       io.NopCloser(strings.NewReader("")),
+			Status:     "409 Conflict",
+			StatusCode: 409,
+			Body: io.NopCloser(strings.NewReader(
+				"{\"detail\": \"Publish in unexpected state\"}",
+			)),
 		}
 
 		err := publish.AddItems(ctx, []ItemInput{{"/some/uri", "abc123"}})
@@ -133,7 +135,7 @@ func TestClientPublishErrors(t *testing.T) {
 		if err == nil {
 			t.Error("Unexpectedly failed to return an error")
 		}
-		if !strings.Contains(err.Error(), "I'm a teapot") {
+		if !strings.Contains(err.Error(), "Publish in unexpected state") {
 			t.Errorf("Did not get expected error, got: %v", err)
 		}
 	})


### PR DESCRIPTION
When exodus-rsync gets an unsuccessful response from exodus-gw, the
response body is now included in the error message produced by
exodus-rsync. Response body is limited to 2000 bytes.