### PR TITLE
Integrate AWS SDK debug logging [RHELDST-5412]

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ rsyncmode: exodus
 #
 # "none"   - no logging
 # "debug"  - for debugging exodus-rsync, very verbose
+# "trace"  - sets debug level for exodus-rsync and the AWS SDK
 # "info"   - outputs messages mostly when writes occur; default, and recommended.
 # "warn"   - outputs messages when possible issues are encountered
 # "error"  - outputs messages when errors occur

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -48,6 +48,9 @@ type Config interface {
 
 	// Specific logger backend (journald or syslog).
 	Logger() string
+
+	// Level of verbosity requested via CLI args.
+	Verbosity() int
 }
 
 // EnvironmentConfig provides configuration specific to one environment.

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -50,7 +50,7 @@ environments:
 	ctx = log.NewContext(ctx, log.Package.NewLogger(args.Config{}))
 
 	var cfg GlobalConfig
-	cfg, err = loadFromPath(filename)
+	cfg, err = loadFromPath(filename, args.Config{})
 
 	if err != nil {
 		t.Fatalf("could not load config file: %v", err)
@@ -102,6 +102,7 @@ func TestDefaultsFromParent(t *testing.T) {
 
 	cfg.GwCertRaw = "cert"
 	cfg.GwPollIntervalRaw = 123
+	cfg.args.Verbose = 1
 
 	env := environment{parent: &cfg}
 
@@ -110,5 +111,8 @@ func TestDefaultsFromParent(t *testing.T) {
 	}
 	if env.GwPollInterval() != 123 {
 		t.Errorf("did not get GwPollInterval from parent")
+	}
+	if env.Verbosity() != 1 {
+		t.Errorf("did not get args.Verbose from parent")
 	}
 }

--- a/internal/conf/load.go
+++ b/internal/conf/load.go
@@ -20,7 +20,7 @@ func candidatePaths() []string {
 	}
 }
 
-func loadFromPath(path string) (*globalConfig, error) {
+func loadFromPath(path string, args args.Config) (*globalConfig, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return &globalConfig{}, err
@@ -29,6 +29,7 @@ func loadFromPath(path string) (*globalConfig, error) {
 
 	dec := yaml.NewDecoder(file)
 	out := &globalConfig{}
+	out.args = args
 
 	err = dec.Decode(&out)
 	if err != nil {
@@ -73,7 +74,7 @@ func (impl) Load(ctx context.Context, args args.Config) (GlobalConfig, error) {
 		_, err := os.Stat(candidate)
 		if err == nil {
 			logger.F("path", candidate).Debug("loading config")
-			return loadFromPath(candidate)
+			return loadFromPath(candidate, args)
 		}
 		logger.F("path", candidate, "error", err).Debug("config file not usable")
 	}

--- a/internal/conf/mock.go
+++ b/internal/conf/mock.go
@@ -199,6 +199,20 @@ func (mr *MockConfigMockRecorder) RsyncMode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RsyncMode", reflect.TypeOf((*MockConfig)(nil).RsyncMode))
 }
 
+// Verbosity mocks base method.
+func (m *MockConfig) Verbosity() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Verbosity")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Verbosity indicates an expected call of Verbosity.
+func (mr *MockConfigMockRecorder) Verbosity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verbosity", reflect.TypeOf((*MockConfig)(nil).Verbosity))
+}
+
 // MockEnvironmentConfig is a mock of EnvironmentConfig interface.
 type MockEnvironmentConfig struct {
 	ctrl     *gomock.Controller
@@ -362,6 +376,20 @@ func (mr *MockEnvironmentConfigMockRecorder) RsyncMode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RsyncMode", reflect.TypeOf((*MockEnvironmentConfig)(nil).RsyncMode))
 }
 
+// Verbosity mocks base method.
+func (m *MockEnvironmentConfig) Verbosity() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Verbosity")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Verbosity indicates an expected call of Verbosity.
+func (mr *MockEnvironmentConfigMockRecorder) Verbosity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verbosity", reflect.TypeOf((*MockEnvironmentConfig)(nil).Verbosity))
+}
+
 // MockGlobalConfig is a mock of GlobalConfig interface.
 type MockGlobalConfig struct {
 	ctrl     *gomock.Controller
@@ -523,4 +551,18 @@ func (m *MockGlobalConfig) RsyncMode() string {
 func (mr *MockGlobalConfigMockRecorder) RsyncMode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RsyncMode", reflect.TypeOf((*MockGlobalConfig)(nil).RsyncMode))
+}
+
+// Verbosity mocks base method.
+func (m *MockGlobalConfig) Verbosity() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Verbosity")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Verbosity indicates an expected call of Verbosity.
+func (mr *MockGlobalConfigMockRecorder) Verbosity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verbosity", reflect.TypeOf((*MockGlobalConfig)(nil).Verbosity))
 }

--- a/internal/conf/structs.go
+++ b/internal/conf/structs.go
@@ -3,6 +3,8 @@ package conf
 import (
 	"fmt"
 	"strings"
+
+	"github.com/release-engineering/exodus-rsync/internal/args"
 )
 
 type sharedConfig struct {
@@ -19,6 +21,7 @@ type sharedConfig struct {
 
 type environment struct {
 	sharedConfig `yaml:",inline"`
+	args         args.Config `embed:"1"`
 
 	PrefixRaw string `yaml:"prefix"`
 
@@ -27,6 +30,7 @@ type environment struct {
 
 type globalConfig struct {
 	sharedConfig `yaml:",inline"`
+	args         args.Config `embed:"1"`
 
 	// Configuration for each environment.
 	EnvironmentsRaw []environment `yaml:"environments"`
@@ -92,6 +96,10 @@ func (g *globalConfig) Logger() string {
 	return nonEmptyString(g.LoggerRaw, "auto")
 }
 
+func (g *globalConfig) Verbosity() int {
+	return g.args.Verbose
+}
+
 func (e *environment) GwCert() string {
 	return nonEmptyString(e.GwCertRaw, e.parent.GwCert())
 }
@@ -126,6 +134,10 @@ func (e *environment) LogLevel() string {
 
 func (e *environment) Logger() string {
 	return nonEmptyString(e.LoggerRaw, e.parent.Logger())
+}
+
+func (e *environment) Verbosity() int {
+	return nonEmptyInt(e.args.Verbose, e.parent.Verbosity())
 }
 
 func (e *environment) Prefix() string {

--- a/internal/gw/helpers_test.go
+++ b/internal/gw/helpers_test.go
@@ -36,6 +36,8 @@ func testConfig(t *testing.T) conf.Config {
 	cfg.EXPECT().GwPollInterval().AnyTimes().Return(1)
 	cfg.EXPECT().GwEnv().AnyTimes().Return("env")
 	cfg.EXPECT().GwBatchSize().AnyTimes().Return(3)
+	cfg.EXPECT().LogLevel().AnyTimes().Return("info")
+	cfg.EXPECT().Verbosity().AnyTimes().Return(3)
 
 	return cfg
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -3,7 +3,10 @@ package log
 import (
 	"testing"
 
+	apexLog "github.com/apex/log"
+	"github.com/apex/log/handlers/memory"
 	"github.com/release-engineering/exodus-rsync/internal/args"
+	"github.com/stretchr/testify/assert"
 )
 
 type testcase struct {
@@ -27,6 +30,7 @@ func TestPlatformLoggers(t *testing.T) {
 		{"debug", "syslog"},
 		{"none", "auto"},
 		{"invalid", "auto"},
+		{"trace", "auto"},
 	}
 
 	for _, tc := range cases {
@@ -65,4 +69,17 @@ func TestPlatformAutoLoggers(t *testing.T) {
 	if handler2 == nil {
 		t.Error("auto with haveJournal=true did not return journald handler")
 	}
+}
+
+func TestLogFunc(t *testing.T) {
+	// Ensure Log can be used and contains the "aws" field.
+	h := memory.New()
+	logger := Package.NewLogger(args.Config{})
+	logger.Handler = h
+
+	logger.Log("hello")
+
+	e := h.Entries[0]
+	assert.Equal(t, e.Message, "hello")
+	assert.Equal(t, apexLog.Fields{"aws": 1}, e.Fields)
 }


### PR DESCRIPTION
This commit adds a new "trace" log level that, when set, enables debug
logging for both exodus-rsync and the AWS SDK. The same effect is
achieved when -v flag is provided three or more times, i.e., "-vvv".