### PR TITLE
docs: fix mistake in --exodus-publish help text

### DIFF
--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -56,7 +56,7 @@ type IgnoredConfig struct {
 type ExodusConfig struct {
 	Conf string `help:"Force usage of this configuration file."`
 
-	Publish string `help:"ID of existing exodus-gw publish to."`
+	Publish string `help:"ID of existing exodus-gw publish to join."`
 }
 
 // Config contains the subset of arguments which are returned by the parser and


### PR DESCRIPTION
There was a sentence fragment here: "...publish to".
I'm pretty sure it was meant to say "...publish to join" which
is consistent with the README.