### PR TITLE
support --files-from argument [RHELDST-7465]

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,10 @@ is a summary of the differences:
   | --delete | ignored; deleting content is not supported |
   | --timeout | ignored |
   | --compress, -z | ignored |
+  | --exclude | exclude files matching this pattern |
+  | --files-from | read list of source-file names from FILE |
   | --stats | ignored |
   | --itemize-changes, -i | ignored |
-  | --exclude | exclude files matching this pattern |
 
 ### Publish modes
 

--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -70,19 +70,20 @@ type Config struct {
 	// e.g., /foo/bar/baz.c remote:/tmp => /tmp/foo/bar/baz.c.
 	Relative bool `short:"R" help:"use relative path names"`
 
+	DryRun bool `short:"n" help:"Perform a trial run with no changes made"`
+
 	// Mostly ignored, but causes a failure if publish contains any files.
 	// See comments where the argument is checked for the explanation why.
 	IgnoreExisting bool `hidden:"1"`
 
-	DryRun bool `short:"n" help:"Perform a trial run with no changes made"`
-
-	Src  string `arg:"1" placeholder:"SRC" help:"Local path to a file or directory for sync"`
-	Dest string `arg:"1" placeholder:"[USER@]HOST:DEST" help:"Remote destination for sync"`
-
 	// This should be parsed but not exposed
 	Filter filterArgument `short:"f" hidden:"1"`
 
-	Exclude []string `placeholder:"PATTERN" help:"Exclude files matching this pattern"`
+	Exclude   []string `placeholder:"PATTERN" help:"Exclude files matching this pattern"`
+	FilesFrom string   `placeholder:"FILE" help:"Read list of source-file names from FILE"`
+
+	Src  string `arg:"1" placeholder:"SRC" help:"Local path to a file or directory for sync"`
+	Dest string `arg:"1" placeholder:"[USER@]HOST:DEST" help:"Remote destination for sync"`
 
 	IgnoredConfig `embed:"1" group:"ignored"`
 	ExodusConfig  `embed:"1" prefix:"exodus-"`

--- a/internal/args/parse_test.go
+++ b/internal/args/parse_test.go
@@ -53,6 +53,15 @@ func TestParseOk(t *testing.T) {
 				"y"},
 			want: Config{Exclude: []string{".*", "*.conf"}, Src: "x", Dest: "y"}},
 
+		"files-from": {
+			input: []string{
+				"exodus-rsync",
+				"--files-from",
+				"sources.txt",
+				"x",
+				"y"},
+			want: Config{FilesFrom: "sources.txt", Src: "x", Dest: "y"}},
+
 		"tolerable filter": {
 			input: []string{
 				"exodus-rsync",

--- a/internal/cmd/cmd_sync_read_errors_test.go
+++ b/internal/cmd/cmd_sync_read_errors_test.go
@@ -49,6 +49,40 @@ func TestMainSyncUnreadableFile(t *testing.T) {
 	}
 }
 
+func TestMainSyncUnreadableFilesFrom(t *testing.T) {
+	SetConfig(t, CONFIG)
+
+	logs := CaptureLogger(t)
+
+	ctrl := MockController(t)
+
+	mockGw := gw.NewMockInterface(ctrl)
+	ext.gw = mockGw
+
+	client := FakeClient{blobs: make(map[string]string)}
+	mockGw.EXPECT().NewClient(gomock.Any(), EnvMatcher{"best-env"}).Return(&client, nil)
+
+	args := []string{"rsync", "--files-from", "/sources.txt", ".", "exodus:/some/target"}
+
+	got := Main(args)
+
+	// It should fail.
+	if got != 73 {
+		t.Error("returned incorrect exit code", got)
+	}
+
+	// It should have told us why.
+	entry := FindEntry(logs, "can't read --files-from file")
+	if entry == nil {
+		t.Fatal("missing expected log message")
+	}
+
+	err := fmt.Sprint(entry.Fields["error"])
+	if !strings.Contains(err, "no such file or directory") {
+		t.Error("unexpected error message", err)
+	}
+}
+
 func TestMainSyncUnreadableDir(t *testing.T) {
 	SetConfig(t, CONFIG)
 

--- a/internal/cmd/cmd_sync_test.go
+++ b/internal/cmd/cmd_sync_test.go
@@ -406,6 +406,75 @@ func TestMainSyncNoSlash(t *testing.T) {
 	}
 }
 
+func TestMainSyncFilesFrom(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	SetConfig(t, CONFIG)
+	ctrl := MockController(t)
+
+	mockGw := gw.NewMockInterface(ctrl)
+	ext.gw = mockGw
+
+	client := FakeClient{blobs: make(map[string]string)}
+	mockGw.EXPECT().NewClient(gomock.Any(), EnvMatcher{"best-env"}).Return(&client, nil)
+
+	srcPath := path.Clean(wd + "/../../test/data/srctrees")
+	filesFromPath := path.Clean(wd + "/../../test/data/source-list.txt")
+
+	args := []string{
+		"rsync",
+		"-vvv",
+		"--files-from", filesFromPath,
+		srcPath + "/",
+		"exodus:/dest",
+	}
+
+	got := Main(args)
+
+	// It should complete successfully.
+	if got != 0 {
+		t.Error("returned incorrect exit code", got)
+	}
+
+	// It should have created one publish.
+	if len(client.publishes) != 1 {
+		t.Error("expected to create 1 publish, instead created", len(client.publishes))
+	}
+
+	p := client.publishes[0]
+
+	// Build up a URI => Key mapping of what was published.
+	itemMap := make(map[string]string)
+	for _, item := range p.items {
+		if _, ok := itemMap[item.WebURI]; ok {
+			t.Error("tried to publish this URI more than once:", item.WebURI)
+		}
+		itemMap[item.WebURI] = item.ObjectKey
+	}
+
+	// Full source path should be preserved, as --relative is implied with --files-from.
+	expPath1 := path.Join("/dest", srcPath, "just-files/subdir/some-binary")
+	expPath2 := path.Join("/dest", srcPath, "some.conf")
+
+	// It should have been exactly this.
+	expectedItems := map[string]string{
+		expPath1: "c66f610d98b2c9fe0175a3e99ba64d7fc7de45046515ff325be56329a9347dd6",
+		expPath2: "4cfe7dba345453b9e2e7a505084238095511ef673e03b6a016f871afe2dfa599",
+	}
+
+	if !reflect.DeepEqual(itemMap, expectedItems) {
+		t.Error("did not publish expected items, published:", itemMap)
+	}
+
+	// It should have committed the publish (once).
+	if p.committed != 1 {
+		t.Error("expected to commit publish (once), instead p.committed ==", p.committed)
+	}
+}
+
 func TestMainSyncJoinPublish(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {

--- a/internal/rsync/rsync.go
+++ b/internal/rsync/rsync.go
@@ -120,17 +120,20 @@ func rsyncArguments(ctx context.Context, cfg conf.Config, args args.Config) []st
 	if args.Compress {
 		argv = append(argv, "--compress")
 	}
-	if args.Stats {
-		argv = append(argv, "--stats")
-	}
-	if args.ItemizeChanges {
-		argv = append(argv, "--itemize-changes")
-	}
 	if args.Filter != "" {
 		argv = append(argv, "--filter", fmt.Sprint(args.Filter))
 	}
 	for _, ex := range args.Exclude {
 		argv = append(argv, "--exclude", fmt.Sprint(ex))
+	}
+	if args.FilesFrom != "" {
+		argv = append(argv, "--files-from", fmt.Sprint(args.FilesFrom))
+	}
+	if args.Stats {
+		argv = append(argv, "--stats")
+	}
+	if args.ItemizeChanges {
+		argv = append(argv, "--itemize-changes")
 	}
 
 	argv = append(argv, args.Src, args.Dest)

--- a/internal/rsync/rsync_test.go
+++ b/internal/rsync/rsync_test.go
@@ -79,6 +79,7 @@ func TestExec(t *testing.T) {
 				IgnoreExisting: true,
 				Filter:         "some-filter",
 				Exclude:        []string{".*"},
+				FilesFrom:      "sources.txt",
 			},
 			[]string{
 				"../../test/bin/rsync", "-vvv",
@@ -86,8 +87,9 @@ func TestExec(t *testing.T) {
 				"--hard-links", "--perms", "--executability", "--acls", "--xattrs",
 				"--owner", "--group", "--devices", "--specials", "--times", "--atimes",
 				"--crtimes", "--omit-dir-times", "--rsh", "some-rsh", "--ignore-existing",
-				"--delete", "--timeout", "1234", "--compress", "--stats",
-				"--itemize-changes", "--filter", "some-filter", "--exclude", ".*", "src", "dest",
+				"--delete", "--timeout", "1234", "--compress", "--filter", "some-filter",
+				"--exclude", ".*", "--files-from", "sources.txt", "--stats", "--itemize-changes",
+				"src", "dest",
 			},
 		},
 	}

--- a/internal/walk/walk_test.go
+++ b/internal/walk/walk_test.go
@@ -34,7 +34,7 @@ func TestWalkEarlyCancel(t *testing.T) {
 		return nil
 	}
 
-	err := Walk(ctx, ".", []string{}, handler)
+	err := Walk(ctx, ".", []string{}, []string{}, handler)
 
 	// It should have returned the cancelled error
 	if err != ctx.Err() {
@@ -61,7 +61,7 @@ func TestWalkCancelInProgress(t *testing.T) {
 		return nil
 	}
 
-	err := Walk(ctx, ".", []string{}, handler)
+	err := Walk(ctx, ".", []string{}, []string{}, handler)
 
 	// It should have returned the cancelled error
 	if err != ctx.Err() {
@@ -80,7 +80,7 @@ func TestWalkHandlerError(t *testing.T) {
 		return fmt.Errorf("simulated error")
 	}
 
-	err := Walk(ctx, ".", []string{}, handler)
+	err := Walk(ctx, ".", []string{}, []string{}, handler)
 
 	// It should have returned the error from handler
 	if err.Error() != "simulated error" {
@@ -99,7 +99,7 @@ func TestWalkExcludeMatchError(t *testing.T) {
 		return nil
 	}
 
-	err := Walk(ctx, ".", []string{"a(b"}, handler)
+	err := Walk(ctx, ".", []string{"a(b"}, []string{}, handler)
 
 	// It should have caused a regexp error
 	msg := "error processing --exclude `a(b`: error parsing regexp: missing closing ): `a(b`"

--- a/test/data/source-list.txt
+++ b/test/data/source-list.txt
@@ -1,0 +1,2 @@
+some.conf
+just-files/subdir/some-binary


### PR DESCRIPTION
exodus-rsync now supports the --files-from argument, accepting the
location of a file which lists specific paths to sync.