### PR TITLE
Support --server and --sender internal arguments [RHELDST-8154]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Support --server, --sender internal arguments
 - Support --include, --filter arguments
 
 ## 1.2.0 - 2021-09-20

--- a/internal/cmd/cmd_sync_mixed_test.go
+++ b/internal/cmd/cmd_sync_mixed_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/release-engineering/exodus-rsync/internal/args"
-	"github.com/release-engineering/exodus-rsync/internal/conf"
 	"github.com/release-engineering/exodus-rsync/internal/gw"
 	"github.com/release-engineering/exodus-rsync/internal/rsync"
 )
@@ -22,8 +21,8 @@ type fakeRsync struct {
 	prefix   []string
 }
 
-func (r *fakeRsync) Command(ctx context.Context, cfg conf.Config, args args.Config) *exec.Cmd {
-	cmd := r.delegate.Command(ctx, cfg, args)
+func (r *fakeRsync) Command(ctx context.Context, args []string) *exec.Cmd {
+	cmd := r.delegate.Command(ctx, args)
 
 	cmd.Path = r.prefix[0]
 	cmd.Args = append(r.prefix, cmd.Args...)
@@ -39,8 +38,12 @@ func (r *fakeRsync) Command(ctx context.Context, cfg conf.Config, args args.Conf
 	return cmd
 }
 
-func (r *fakeRsync) Exec(ctx context.Context, cfg conf.Config, args args.Config) error {
+func (r *fakeRsync) Exec(ctx context.Context, args args.Config) error {
 	return fmt.Errorf("this test is not supposed to Exec")
+}
+
+func (r *fakeRsync) RawExec(ctx context.Context, args []string) error {
+	return fmt.Errorf("this test is not supposed to RawExec")
 }
 
 func TestMainSyncMixedOk(t *testing.T) {

--- a/internal/cmd/cmd_unreadable_conf_test.go
+++ b/internal/cmd/cmd_unreadable_conf_test.go
@@ -63,7 +63,7 @@ func TestMainNonexistentConf(t *testing.T) {
 	// an error.
 	rsyncError := fmt.Errorf("simulated error")
 
-	mockRsync.EXPECT().Exec(gomock.Any(), nil, parsedArgs).Return(rsyncError)
+	mockRsync.EXPECT().Exec(gomock.Any(), parsedArgs).Return(rsyncError)
 
 	got := Main(rawArgs)
 

--- a/internal/cmd/mixed.go
+++ b/internal/cmd/mixed.go
@@ -10,6 +10,7 @@ import (
 	"github.com/release-engineering/exodus-rsync/internal/args"
 	"github.com/release-engineering/exodus-rsync/internal/conf"
 	"github.com/release-engineering/exodus-rsync/internal/log"
+	"github.com/release-engineering/exodus-rsync/internal/rsync"
 )
 
 // Mixed publish mode, publishing both via exodus and rsync.
@@ -50,7 +51,7 @@ func mixedMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 	var lastCode *chan int
 	rsyncCode := make(chan int, 1)
 	exodusCode := make(chan int, 1)
-	rsyncCmd := ext.rsync.Command(ctx, cfg, args)
+	rsyncCmd := ext.rsync.Command(ctx, rsync.Arguments(ctx, args))
 
 	// Let rsync & exodus publishes run in their own goroutines.
 	go func() {

--- a/internal/cmd/rsync.go
+++ b/internal/cmd/rsync.go
@@ -14,7 +14,24 @@ func rsyncMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 
 	// Just run rsync. In the successful case, since we're doing execve system
 	// call, this will never return.
-	if err := ext.rsync.Exec(ctx, cfg, args); err != nil {
+	if err := ext.rsync.Exec(ctx, args); err != nil {
+		logger.WithField("error", err).Error("can't exec rsync")
+		exitCode = 94
+	}
+
+	return exitCode
+}
+
+func rsyncRaw(ctx context.Context, rawArgs []string) int {
+	logger := log.FromContext(ctx)
+	exitCode := 0
+
+	// Trim command name from raw argv.
+	args := rawArgs[1:]
+
+	// Just run rsync. In the successful case, since we're doing execve system
+	// call, this will never return.
+	if err := ext.rsync.RawExec(ctx, args); err != nil {
 		logger.WithField("error", err).Error("can't exec rsync")
 		exitCode = 94
 	}

--- a/internal/rsync/lookup_test.go
+++ b/internal/rsync/lookup_test.go
@@ -7,9 +7,7 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/release-engineering/exodus-rsync/internal/args"
-	"github.com/release-engineering/exodus-rsync/internal/conf"
 	"github.com/release-engineering/exodus-rsync/internal/log"
 )
 
@@ -28,15 +26,12 @@ func setPath(t *testing.T, value string) {
 // If an rsync command can't be located, /usr/bin/rsync is used
 // as fallback.
 func TestCommandFallback(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	conf := conf.NewMockConfig(ctrl)
-
 	// No PATH at all means no rsync in PATH
 	setPath(t, "")
 
 	ctx := log.NewContext(context.Background(), log.Package.NewLogger(args.Config{}))
 
-	cmd := Package.Command(ctx, conf, args.Config{})
+	cmd := Package.Command(ctx, []string{})
 
 	if cmd.Path != "/usr/bin/rsync" {
 		t.Errorf("command returned unexpected path %v", cmd.Path)
@@ -72,11 +67,9 @@ func TestCommandAvoidSelf(t *testing.T) {
 		t.Fatalf("sanity check of test setup failed, lookup of rsync returned %v", foundRsync)
 	}
 
-	ctrl := gomock.NewController(t)
-	conf := conf.NewMockConfig(ctrl)
 	ctx := log.NewContext(context.Background(), log.Package.NewLogger(args.Config{}))
 
-	cmd := Package.Command(ctx, conf, args.Config{})
+	cmd := Package.Command(ctx, []string{})
 
 	// Rather than looking up ourselves as a plain LookPath did, it should be smart
 	// enough to remove self from path and find the "real" rsync

--- a/internal/rsync/mock.go
+++ b/internal/rsync/mock.go
@@ -11,7 +11,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	args "github.com/release-engineering/exodus-rsync/internal/args"
-	conf "github.com/release-engineering/exodus-rsync/internal/conf"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -38,29 +37,43 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Command mocks base method.
-func (m *MockInterface) Command(arg0 context.Context, arg1 conf.Config, arg2 args.Config) *exec.Cmd {
+func (m *MockInterface) Command(arg0 context.Context, arg1 []string) *exec.Cmd {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Command", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Command", arg0, arg1)
 	ret0, _ := ret[0].(*exec.Cmd)
 	return ret0
 }
 
 // Command indicates an expected call of Command.
-func (mr *MockInterfaceMockRecorder) Command(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Command(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockInterface)(nil).Command), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockInterface)(nil).Command), arg0, arg1)
 }
 
 // Exec mocks base method.
-func (m *MockInterface) Exec(arg0 context.Context, arg1 conf.Config, arg2 args.Config) error {
+func (m *MockInterface) Exec(arg0 context.Context, arg1 args.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exec", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Exec", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Exec indicates an expected call of Exec.
-func (mr *MockInterfaceMockRecorder) Exec(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Exec(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockInterface)(nil).Exec), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockInterface)(nil).Exec), arg0, arg1)
+}
+
+// RawExec mocks base method.
+func (m *MockInterface) RawExec(arg0 context.Context, arg1 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RawExec", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RawExec indicates an expected call of RawExec.
+func (mr *MockInterfaceMockRecorder) RawExec(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RawExec", reflect.TypeOf((*MockInterface)(nil).RawExec), arg0, arg1)
 }


### PR DESCRIPTION
These flags, used internally by rsync and hidden from users, cause
exodus-rsync to immediately execute rsync with only raw arguments.