### PR TITLE
Fix: support logging complex objects with syslog

### DIFF
--- a/internal/log/journald.go
+++ b/internal/log/journald.go
@@ -3,12 +3,17 @@ package log
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	apexLog "github.com/apex/log"
 	"github.com/coreos/go-systemd/v22/journal"
 )
 
-type journalHandler struct{}
+type journalHandler struct {
+	test    bool
+	mutex   sync.Mutex
+	Entries []string
+}
 
 func newJournalHandler() apexLog.Handler {
 	return &journalHandler{}
@@ -27,7 +32,7 @@ func priority(e *apexLog.Entry) journal.Priority {
 	return journal.PriDebug
 }
 
-func fields(e *apexLog.Entry) map[string]string {
+func journalFields(e *apexLog.Entry) map[string]string {
 	out := make(map[string]string)
 
 	for key := range e.Fields {
@@ -42,7 +47,18 @@ func fields(e *apexLog.Entry) map[string]string {
 func (h *journalHandler) HandleLog(e *apexLog.Entry) error {
 	msg := e.Message
 	pri := priority(e)
-	fields := fields(e)
+	fields := journalFields(e)
+
+	if h.test {
+		h.mutex.Lock()
+		defer h.mutex.Unlock()
+
+		var sFields string
+		for k, v := range fields {
+			sFields += fmt.Sprintf("%s=%s", k, v)
+		}
+		h.Entries = append(h.Entries, msg+" "+sFields)
+	}
 
 	return journal.Send(msg, pri, fields)
 }

--- a/internal/log/syslog.go
+++ b/internal/log/syslog.go
@@ -2,14 +2,19 @@ package log
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/syslog"
 	"strings"
+	"sync"
 
 	apexLog "github.com/apex/log"
 )
 
 type syslogHandler struct {
-	writer *syslog.Writer
+	writer  *syslog.Writer
+	test    bool
+	mutex   sync.Mutex
+	Entries []string
 }
 
 type writeFunc func(string) error
@@ -38,12 +43,30 @@ func (h *syslogHandler) writerForLevel(l apexLog.Level) writeFunc {
 	return h.writer.Debug
 }
 
+func syslogFields(e *apexLog.Entry) map[string]string {
+	out := make(map[string]string)
+
+	for key := range e.Fields {
+		val := fmt.Sprint(e.Fields[key])
+		out[key] = val
+	}
+
+	return out
+}
+
 func (h *syslogHandler) HandleLog(e *apexLog.Entry) error {
 	bld := strings.Builder{}
 	bld.WriteString(e.Message + " ")
 
 	enc := json.NewEncoder(&bld)
-	enc.Encode(e.Fields)
+	enc.Encode(syslogFields(e))
+
+	if h.test {
+		h.mutex.Lock()
+		defer h.mutex.Unlock()
+
+		h.Entries = append(h.Entries, bld.String())
+	}
 
 	return h.writerForLevel(e.Level)(bld.String())
 }


### PR DESCRIPTION
Added field mapping to syslog entries prior to JSON encoding.

Additionally, handlers now have the ability to expose log messages.
Set handler.test = true to store all logs in handler.Entries.