### PR TITLE
Strip prefix from destination path [RHELDST-8581]

### DIFF
--- a/internal/cmd/cmd_bad_conf_test.go
+++ b/internal/cmd/cmd_bad_conf_test.go
@@ -23,6 +23,13 @@ environments:
 - prefix: exodus
   gwenv: test2
 `},
+		{"invalid prefix stripped",
+			`
+strip: test
+environments:
+- prefix: exodus
+  gwenv: test
+`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cmd/cmd_sync_test.go
+++ b/internal/cmd/cmd_sync_test.go
@@ -22,6 +22,15 @@ environments:
 - prefix: exodus-mixed
   gwenv: best-env
   rsyncmode: mixed
+
+- prefix: somehost:/cdn/root
+  gwenv: best-env
+  rsyncmode: exodus
+
+- prefix: otherhost:/foo/bar/baz
+  gwenv: best-env
+  rsyncmode: exodus
+  strip: otherhost:/foo
 `
 
 type EnvMatcher struct {
@@ -627,5 +636,162 @@ func TestMainSyncJoinPublish(t *testing.T) {
 
 	if !reflect.DeepEqual(itemMap, expectedItems) {
 		t.Error("did not publish expected items, published:", itemMap)
+	}
+}
+
+func TestMainStripFromPrefix(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	SetConfig(t, CONFIG)
+	ctrl := MockController(t)
+
+	mockGw := gw.NewMockInterface(ctrl)
+	ext.gw = mockGw
+
+	client := FakeClient{blobs: make(map[string]string)}
+	mockGw.EXPECT().NewClient(gomock.Any(), EnvMatcher{"best-env"}).Return(&client, nil)
+
+	srcPath := path.Clean(wd + "/../../test/data/srctrees/just-files")
+
+	args := []string{
+		"rsync",
+		srcPath + "/",
+		"otherhost:/foo/bar/baz/my/dest",
+	}
+
+	got := Main(args)
+
+	// It should complete successfully.
+	if got != 0 {
+		t.Error("returned incorrect exit code", got)
+	}
+
+	// Check paths of some blobs we expected to deal with.
+	binPath := client.blobs["c66f610d98b2c9fe0175a3e99ba64d7fc7de45046515ff325be56329a9347dd6"]
+	helloPath := client.blobs["5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"]
+
+	// It should have uploaded the binary from here
+	if binPath != srcPath+"/subdir/some-binary" {
+		t.Error("binary uploaded from unexpected path", binPath)
+	}
+
+	// For the hello file, since there were two copies, it's undefined which one of them
+	// was used for the upload - but should be one of them.
+	if helloPath != srcPath+"/hello-copy-one" && helloPath != srcPath+"/hello-copy-two" {
+		t.Error("hello uploaded from unexpected path", helloPath)
+	}
+
+	// It should have created one publish.
+	if len(client.publishes) != 1 {
+		t.Error("expected to create 1 publish, instead created", len(client.publishes))
+	}
+
+	p := client.publishes[0]
+
+	// Build up a URI => Key mapping of what was published
+	itemMap := make(map[string]string)
+	for _, item := range p.items {
+		if _, ok := itemMap[item.WebURI]; ok {
+			t.Error("tried to publish this URI more than once:", item.WebURI)
+		}
+		itemMap[item.WebURI] = item.ObjectKey
+	}
+
+	// It should have been exactly this
+	expectedItems := map[string]string{
+		"/bar/baz/my/dest/subdir/some-binary": "c66f610d98b2c9fe0175a3e99ba64d7fc7de45046515ff325be56329a9347dd6",
+		"/bar/baz/my/dest/hello-copy-one":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+		"/bar/baz/my/dest/hello-copy-two":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+	}
+
+	if !reflect.DeepEqual(itemMap, expectedItems) {
+		t.Error("did not publish expected items, published:", itemMap)
+	}
+
+	// It should have committed the publish (once)
+	if p.committed != 1 {
+		t.Error("expected to commit publish (once), instead p.committed ==", p.committed)
+	}
+}
+
+func TestMainStripDefaultPrefix(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	SetConfig(t, CONFIG)
+	ctrl := MockController(t)
+
+	mockGw := gw.NewMockInterface(ctrl)
+	ext.gw = mockGw
+
+	client := FakeClient{blobs: make(map[string]string)}
+	mockGw.EXPECT().NewClient(gomock.Any(), EnvMatcher{"best-env"}).Return(&client, nil)
+
+	srcPath := path.Clean(wd + "/../../test/data/srctrees/just-files")
+
+	args := []string{
+		"rsync",
+		"-vvv",
+		srcPath + "/",
+		"somehost:/cdn/root/my/dest",
+	}
+
+	got := Main(args)
+
+	// It should complete successfully.
+	if got != 0 {
+		t.Error("returned incorrect exit code", got)
+	}
+
+	// Check paths of some blobs we expected to deal with.
+	binPath := client.blobs["c66f610d98b2c9fe0175a3e99ba64d7fc7de45046515ff325be56329a9347dd6"]
+	helloPath := client.blobs["5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"]
+
+	// It should have uploaded the binary from here
+	if binPath != srcPath+"/subdir/some-binary" {
+		t.Error("binary uploaded from unexpected path", binPath)
+	}
+
+	// For the hello file, since there were two copies, it's undefined which one of them
+	// was used for the upload - but should be one of them.
+	if helloPath != srcPath+"/hello-copy-one" && helloPath != srcPath+"/hello-copy-two" {
+		t.Error("hello uploaded from unexpected path", helloPath)
+	}
+
+	// It should have created one publish.
+	if len(client.publishes) != 1 {
+		t.Error("expected to create 1 publish, instead created", len(client.publishes))
+	}
+
+	p := client.publishes[0]
+
+	// Build up a URI => Key mapping of what was published
+	itemMap := make(map[string]string)
+	for _, item := range p.items {
+		if _, ok := itemMap[item.WebURI]; ok {
+			t.Error("tried to publish this URI more than once:", item.WebURI)
+		}
+		itemMap[item.WebURI] = item.ObjectKey
+	}
+
+	// It should have been exactly this
+	expectedItems := map[string]string{
+		"/my/dest/subdir/some-binary": "c66f610d98b2c9fe0175a3e99ba64d7fc7de45046515ff325be56329a9347dd6",
+		"/my/dest/hello-copy-one":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+		"/my/dest/hello-copy-two":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+	}
+
+	if !reflect.DeepEqual(itemMap, expectedItems) {
+		t.Error("did not publish expected items, published:", itemMap)
+	}
+
+	// It should have committed the publish (once)
+	if p.committed != 1 {
+		t.Error("expected to commit publish (once), instead p.committed ==", p.committed)
 	}
 }

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -54,6 +54,9 @@ type Config interface {
 
 	// Diagnostics mode.
 	Diag() bool
+
+	// Strips this prefix from the destination path of exodus publish items.
+	Strip() string
 }
 
 // EnvironmentConfig provides configuration specific to one environment.

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -32,13 +32,15 @@ gwurl: https://exodus-gw.example.com
 gwcert: global-cert
 gwkey: global-key
 gwbatchsize: 100
+strip: dest:/foo
 
 environments:
-- prefix: dest
+- prefix: dest:/foo/bar/baz
   gwenv: one-env
   gwkey: override-key
   gwpollinterval: 123
   rsyncmode: mixed
+  strip: dest:/foo/bar
 
 `), 0755)
 
@@ -56,7 +58,7 @@ environments:
 		t.Fatalf("could not load config file: %v", err)
 	}
 
-	env := cfg.EnvironmentForDest(ctx, "dest:/foo/bar")
+	env := cfg.EnvironmentForDest(ctx, "dest:/foo/bar/baz")
 
 	// It should be able to get the environment.
 	if env == nil {
@@ -84,12 +86,14 @@ environments:
 	assertEqual("global gwenv", cfg.GwEnv(), "global-env")
 	assertEqual("global gwpollinterval", cfg.GwPollInterval(), 5000)
 	assertEqual("global rsyncmode", cfg.RsyncMode(), "exodus")
+	assertEqual("global strip", cfg.Strip(), "dest:/foo")
 
 	// Values can be overridden in environment.
 	assertEqual("env gwenv", env.GwEnv(), "one-env")
 	assertEqual("env gwkey", env.GwKey(), "override-key")
 	assertEqual("env gwpollinterval", env.GwPollInterval(), 123)
 	assertEqual("env rsyncmode", env.RsyncMode(), "mixed")
+	assertEqual("env strip", env.Strip(), "dest:/foo/bar")
 
 	// For values which are NOT overridden, they should be equal to global.
 	assertEqual("env gwurl", env.GwURL(), cfg.GwURL())

--- a/internal/conf/load.go
+++ b/internal/conf/load.go
@@ -52,11 +52,15 @@ func loadFromPath(path string, args args.Config) (*globalConfig, error) {
 	prefs := map[string]bool{}
 	for i := range out.EnvironmentsRaw {
 		env := &out.EnvironmentsRaw[i]
+		if !strings.HasPrefix(env.Prefix(), out.Strip()) {
+			return nil, fmt.Errorf("cannot strip '%s' prefix from '%s'", out.Strip(), env.Prefix())
+		}
 		if prefs[env.Prefix()] {
 			return nil, fmt.Errorf("duplicate environment definitions for '%s'", env.Prefix())
 		}
 		prefs[env.Prefix()] = true
 		out.EnvironmentsRaw[i].parent = out
+
 	}
 
 	return out, nil
@@ -89,7 +93,11 @@ func (c *globalConfig) EnvironmentForDest(ctx context.Context, dest string) Envi
 
 	for i := range c.EnvironmentsRaw {
 		out := &c.EnvironmentsRaw[i]
-		if strings.HasPrefix(dest, out.Prefix()+":") {
+		prefix := out.Prefix()
+		if !strings.Contains(prefix, ":") {
+			prefix = prefix + ":"
+		}
+		if strings.HasPrefix(dest, prefix) {
 			return out
 		}
 	}

--- a/internal/conf/mock.go
+++ b/internal/conf/mock.go
@@ -213,6 +213,20 @@ func (mr *MockConfigMockRecorder) RsyncMode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RsyncMode", reflect.TypeOf((*MockConfig)(nil).RsyncMode))
 }
 
+// Strip mocks base method.
+func (m *MockConfig) Strip() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Strip")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Strip indicates an expected call of Strip.
+func (mr *MockConfigMockRecorder) Strip() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Strip", reflect.TypeOf((*MockConfig)(nil).Strip))
+}
+
 // Verbosity mocks base method.
 func (m *MockConfig) Verbosity() int {
 	m.ctrl.T.Helper()
@@ -404,6 +418,20 @@ func (mr *MockEnvironmentConfigMockRecorder) RsyncMode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RsyncMode", reflect.TypeOf((*MockEnvironmentConfig)(nil).RsyncMode))
 }
 
+// Strip mocks base method.
+func (m *MockEnvironmentConfig) Strip() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Strip")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Strip indicates an expected call of Strip.
+func (mr *MockEnvironmentConfigMockRecorder) Strip() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Strip", reflect.TypeOf((*MockEnvironmentConfig)(nil).Strip))
+}
+
 // Verbosity mocks base method.
 func (m *MockEnvironmentConfig) Verbosity() int {
 	m.ctrl.T.Helper()
@@ -593,6 +621,20 @@ func (m *MockGlobalConfig) RsyncMode() string {
 func (mr *MockGlobalConfigMockRecorder) RsyncMode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RsyncMode", reflect.TypeOf((*MockGlobalConfig)(nil).RsyncMode))
+}
+
+// Strip mocks base method.
+func (m *MockGlobalConfig) Strip() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Strip")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Strip indicates an expected call of Strip.
+func (mr *MockGlobalConfigMockRecorder) Strip() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Strip", reflect.TypeOf((*MockGlobalConfig)(nil).Strip))
 }
 
 // Verbosity mocks base method.

--- a/internal/conf/structs.go
+++ b/internal/conf/structs.go
@@ -18,6 +18,7 @@ type sharedConfig struct {
 	LogLevelRaw       string `yaml:"loglevel"`
 	LoggerRaw         string `yaml:"logger"`
 	DiagRaw           bool   `yaml:"diag"`
+	StripRaw          string `yaml:"strip"`
 }
 
 type environment struct {
@@ -105,6 +106,10 @@ func (g *globalConfig) Diag() bool {
 	return g.args.Diag || g.DiagRaw
 }
 
+func (g *globalConfig) Strip() string {
+	return g.StripRaw
+}
+
 func (e *environment) GwCert() string {
 	return nonEmptyString(e.GwCertRaw, e.parent.GwCert())
 }
@@ -151,4 +156,11 @@ func (e *environment) Diag() bool {
 
 func (e *environment) Prefix() string {
 	return e.PrefixRaw
+}
+
+func (e *environment) Strip() string {
+	// If the 'strip:' key is defined in the global config, the environment's prefix will not
+	// be stripped from the destination path by default. The prefix is only stripped from the
+	// destination path if the 'strip:' key is undefined.
+	return nonEmptyString(nonEmptyString(e.StripRaw, e.parent.Strip()), e.PrefixRaw)
 }

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -105,12 +105,14 @@ func logCommand(ctx context.Context, cfg conf.Config, args args.Config) {
 	envConfig, isEnv := cfg.(conf.EnvironmentConfig)
 
 	prefix := "<no prefix matched in config>"
+	strip := cfg.Strip()
 
 	if isEnv {
 		prefix = envConfig.Prefix()
 	}
 
-	logger.F("src", args.Src, "dest", args.Dest, "prefix", prefix).Warn("paths")
+	logger.F("src", args.Src, "dest", args.Dest, "prefix", prefix,
+		"strip", strip).Warn("paths")
 
 	cmd := ext.rsync.Command(ctx, rsync.Arguments(ctx, args))
 	logger.F("mode", cfg.RsyncMode(), "path", cmd.Path, "args", cmd.Args).Warn("rsync")

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -29,6 +29,7 @@ func mockConfig(ctrl *gomock.Controller) conf.Config {
 	e.Logger().Return("syslog").AnyTimes()
 	e.Verbosity().Return(3).AnyTimes()
 	e.Prefix().Return("test-prefix").AnyTimes()
+	e.Strip().Return("").AnyTimes()
 
 	return out
 }


### PR DESCRIPTION
If a leading path is included in the 'prefix' defined in
exodus-rsync.conf, the entire prefix, including the leading path,
is stripped from the exodus destination path.

A user may also explicitly control which portion of the prefix is
stripped.

For example, if provided the following config:

  environments:
  - prefix: somehost:/cdn/root
    rsyncmode: exodus

  - prefix: otherhost:/foo/bar/baz
    rsyncmode: exodus
    strip: otherhost:/foo

1. If a user runs

     "exodus-rsync ./src/my-file somehost:/cdn/root/my/dest",

   exodus-rsync will publish "/my/dest/my-file" because the string
   "somehost:/cdn/root" is stripped from the destination path.

2. If a user runs

     "exodus-rsync ./src/my-file otherhost:/foo/bar/baz/my/dest",

   exodus-rsync will publish "/bar/baz/my/dest/my-file" because
   the default stripped prefix has been explicitly overridden to
   "otherhost:/foo", rather than the default of "otherhost:/foo/bar/baz".