### PR TITLE
Make syslog logger more useful

### DIFF
--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -71,6 +71,11 @@ func logConfig(ctx context.Context, cfg conf.Config) {
 		"logger", cfg.Logger(),
 		"verbosity", cfg.Verbosity(),
 	).Warn("logging")
+
+	logger.Debug("This is a DEBUG log.")
+	logger.Info("This is an INFO log.")
+	logger.Warn("This is a WARNING log.")
+	logger.Error("This is an ERROR log.")
 }
 
 func logGw(ctx context.Context, cfg conf.Config) {

--- a/internal/log/syslog.go
+++ b/internal/log/syslog.go
@@ -22,7 +22,7 @@ type writeFunc func(string) error
 func newSyslogHandler() apexLog.Handler {
 	out := syslogHandler{}
 
-	writer, err := syslog.New(syslog.LOG_INFO, "")
+	writer, err := syslog.New(syslog.LOG_INFO, "exodus-rsync")
 	if err == nil {
 		out.writer = writer
 	}
@@ -37,10 +37,9 @@ func (h *syslogHandler) writerForLevel(l apexLog.Level) writeFunc {
 	if l == apexLog.WarnLevel {
 		return h.writer.Warning
 	}
-	if l == apexLog.InfoLevel {
-		return h.writer.Info
-	}
-	return h.writer.Debug
+	// We will not go any lower than INFO severity here because such
+	// messages will often be filtered by syslog itself.
+	return h.writer.Info
 }
 
 func syslogFields(e *apexLog.Entry) map[string]string {


### PR DESCRIPTION
Tweak the syslog setup to address some issues:

- it's best to explicitly set a tag of "exodus-rsync" rather than use
  the default, otherwise we can't easily locate all logs produced by
  exodus-rsync.

- it's best not to produce syslog events at DEBUG level. In the default
  rsyslog config shipped on RHEL7, only events of INFO level and higher
  end up recorded on /var/log/messages. If exodus-rsync.conf has set
  loglevel: debug, the intent is that DEBUG messages shall be logged, so
  it's better to use a syslog level which will achieve that in a typical
  setup.

- adding log messages of each level during diagnostic mode can help to
  confirm that the logging config is working correctly, in case there
  are any more issues in this area.