### PR TITLE
Strip prefix from destination path for link_to items [RHELDST-8581]

### DIFF
--- a/internal/cmd/cmd_sync_test.go
+++ b/internal/cmd/cmd_sync_test.go
@@ -376,7 +376,7 @@ func TestMainSyncDontFollowLinks(t *testing.T) {
 		"rsync",
 		"-lvvv",
 		srcPath + "/",
-		"exodus:/some/target",
+		"somehost:/cdn/root/some/target",
 	}
 
 	got := Main(args)


### PR DESCRIPTION
The previous commit that stripped the prefix from the destination
path did not include link_to items.