### PR TITLE
--files-from shouldn't duplicate source-spec path [RHELDST-8814]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- n/a
+- --files-from shouldn't duplicate source-spec path
 
 ## 1.6.0 - 2021-11-17
 

--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -132,12 +132,16 @@ func (c *Config) Included() []string {
 // on the command-line.
 // For example, if invoked with user@host.example.com:/some/dir,
 // this will return "/some/dir".
+//
 // If relative paths are requested (-R), appends the source path to the
 // destination path, e.g., /foo/bar/baz.c remote:/tmp => /tmp/foo/bar/baz.c.
+//
+// If --files-from is used, listed files are located relative to the source
+// path but the destination path is not altered like in the above example.
 func (c *Config) DestPath() string {
 	if strings.Contains(c.Dest, ":") {
 		dest := strings.SplitN(c.Dest, ":", 2)[1]
-		if c.Relative {
+		if c.Relative && c.FilesFrom == "" {
 			dest = path.Join(dest, c.Src)
 		}
 		return dest

--- a/test/data/source-list.txt
+++ b/test/data/source-list.txt
@@ -1,2 +1,2 @@
-some.conf
-just-files/subdir/some-binary
+srctrees/some.conf
+srctrees/just-files/subdir/some-binary


### PR DESCRIPTION
Previously, due to an oversight, the source path was appended to the
destination path when --files-from was used, due to the option's
implied --relative. This resulted in incorrect web_uri paths for such
files. Now --files-from is checked before this --relative alteration.