### PR TITLE
Fix: --exclude ".*" handling [RHELDST-8934]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- n/a
+- Fix: include/exclude pattern matching differs from rsync
 
 ## 1.7.0 - 2021-11-24
 


### PR DESCRIPTION
Previously, the pattern '.*' was directly passed to regexp which matched,
and therefore excluded, every path processed.

Now '.*' matches only directories or files beginning with a period (.)
as standard rsync does.

Additionally, other differences in include/exclude pattern matching between
rsync and exodus-rsync were discovered. Changes necessary to correct those
issues are included.