### PR TITLE
Fix: include/exclude matching against whole file path [RHELDST-8934]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: include/exclude matches against full path
 - Fix: include/exclude pattern matching differs from rsync
 
 ## 1.7.0 - 2021-11-24

--- a/internal/cmd/cmd_sync_test.go
+++ b/internal/cmd/cmd_sync_test.go
@@ -287,6 +287,80 @@ func TestMainSyncFilter(t *testing.T) {
 	}
 }
 
+func TestMainSyncFilterIsRelative(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	SetConfig(t, CONFIG)
+	ctrl := MockController(t)
+
+	mockGw := gw.NewMockInterface(ctrl)
+	ext.gw = mockGw
+
+	client := FakeClient{blobs: make(map[string]string)}
+	mockGw.EXPECT().NewClient(gomock.Any(), EnvMatcher{"best-env"}).Return(&client, nil)
+
+	srcPath := path.Clean(wd + "/../../test/data/srctrees/just-files")
+
+	// Nothing should match --exclude, as filtered paths are relative.
+	args := []string{
+		"rsync",
+		"--exclude", path.Clean(wd),
+		srcPath + "/",
+		"exodus:/some/target",
+	}
+
+	got := Main(args)
+
+	// It should complete successfully.
+	if got != 0 {
+		t.Error("returned incorrect exit code", got)
+	}
+
+	// Check paths of some blobs we expected to deal with.
+	helloPath := client.blobs["5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"]
+
+	// For the hello file, since there were two copies, it's undefined which one of them
+	// was used for the upload - but should be one of them.
+	if helloPath != srcPath+"/hello-copy-one" && helloPath != srcPath+"/hello-copy-two" {
+		t.Error("hello uploaded from unexpected path", helloPath)
+	}
+
+	// It should have created one publish.
+	if len(client.publishes) != 1 {
+		t.Error("expected to create 1 publish, instead created", len(client.publishes))
+	}
+
+	p := client.publishes[0]
+
+	// Build up a URI => Key mapping of what was published
+	itemMap := make(map[string]string)
+	for _, item := range p.items {
+		if _, ok := itemMap[item.WebURI]; ok {
+			t.Error("tried to publish this URI more than once:", item.WebURI)
+		}
+		itemMap[item.WebURI] = item.ObjectKey
+	}
+
+	// It should have been exactly this
+	expectedItems := map[string]string{
+		"/some/target/hello-copy-one":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+		"/some/target/hello-copy-two":     "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+		"/some/target/subdir/some-binary": "c66f610d98b2c9fe0175a3e99ba64d7fc7de45046515ff325be56329a9347dd6",
+	}
+
+	if !reflect.DeepEqual(itemMap, expectedItems) {
+		t.Error("did not publish expected items, published:", itemMap)
+	}
+
+	// It should have committed the publish (once)
+	if p.committed != 1 {
+		t.Error("expected to commit publish (once), instead p.committed ==", p.committed)
+	}
+}
+
 func TestMainSyncFollowsLinks(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {

--- a/internal/cmd/exodus.go
+++ b/internal/cmd/exodus.go
@@ -84,7 +84,7 @@ func exodusMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 		}
 	}
 
-	err = walk.Walk(ctx, args.Src, args.Excluded(), args.Included(), onlyThese, args.Links, func(item walk.SyncItem) error {
+	err = walk.Walk(ctx, args, onlyThese, func(item walk.SyncItem) error {
 		if args.IgnoreExisting {
 			// This argument is not (properly) supported, so bail out.
 			//


### PR DESCRIPTION
Previously, the whole file path was matched against rather than just the
relative portion. So, for example, if the source directory was excluded,
nothing would be published.

This commit removes the source tree portion of the file path so that
only the relative portion is used when filtering.