### PR TITLE
Fix: source dir basename included in destination path [RHELDST-9158]

### DIFF
--- a/internal/cmd/cmd_sync_test.go
+++ b/internal/cmd/cmd_sync_test.go
@@ -602,7 +602,7 @@ func TestMainSyncFilesFrom(t *testing.T) {
 		"rsync",
 		"-vvv",
 		"--files-from", filesFromPath,
-		srcPath + "/",
+		srcPath,
 		"exodus:/dest",
 	}
 

--- a/internal/cmd/exodus.go
+++ b/internal/cmd/exodus.go
@@ -75,6 +75,12 @@ func exodusMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 	if args.FilesFrom != "" {
 		args.Relative = true
 
+		// When using --files-from, we don't want to recreate the source directory.
+		// Ensure the source path ends with a slash (/), indicating we only want it's contents.
+		if !strings.HasSuffix(args.Src, "/") {
+			args.Src += "/"
+		}
+
 		f, err := os.Open(args.FilesFrom)
 		if err != nil {
 			logger.F("src", args.Src, "error", err).Error("can't read --files-from file")


### PR DESCRIPTION
When the command uses --files-from, rsync never recreates the source
directory at the destination. In exodus mode, this behavior wasn't
replicated, producing destination paths with the source dir basename
when no trailing slash is present.

This commit ensures that, when --files-from is used, source paths are
always treated as if they have a trailing slash.