### PR TITLE
More variables support env var expansion [RHELDST-7401]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ gwcert: $HOME/certs/$USER.crt
 gwkey: $HOME/certs/$USER.key
 
 # Base URL of the exodus-gw service to be used.
+# The base URL may be set using an environment variable.
 gwurl: https://exodus-gw.example.com
 
 # Defines the exodus-gw "environment" for use.
@@ -82,6 +83,8 @@ gwurl: https://exodus-gw.example.com
 #
 # Additionally, the `gwcert` in use must grant the necessary roles for writing to
 # this environment, such as `prod-blob-uploader`, `prod-publisher`.
+#
+# The exodus-gw environment may be set using an environment variable.
 gwenv: prod
 
 ###############################################################################

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -27,7 +27,7 @@ func TestOverrideValues(t *testing.T) {
 	err := os.WriteFile(filename, []byte(`
 
 # Some global values.
-gwenv: global-env
+gwenv: $TEST_EXODUS_GW_ENV
 gwurl: https://exodus-gw.example.com
 gwcert: global-cert
 gwkey: global-key
@@ -46,6 +46,12 @@ environments:
 
 	if err != nil {
 		t.Fatalf("could not write config file for test: %v", err)
+	}
+
+	oldEnv := os.Getenv("TEST_EXODUS_GW_ENV")
+	err = os.Setenv("TEST_EXODUS_GW_ENV", "global-env")
+	if err != nil {
+		t.Fatalf("could not set TEST_EXODUS_GW_ENV, err = %v", err)
 	}
 
 	ctx := context.Background()
@@ -99,6 +105,10 @@ environments:
 	assertEqual("env gwurl", env.GwURL(), cfg.GwURL())
 	assertEqual("env gwcert", env.GwCert(), cfg.GwCert())
 	assertEqual("env gwbatchsize", env.GwBatchSize(), cfg.GwBatchSize())
+
+	t.Cleanup(func() {
+		os.Setenv("TEST_EXODUS_GW_ENV", oldEnv)
+	})
 }
 
 func TestDefaultsFromParent(t *testing.T) {

--- a/internal/conf/load.go
+++ b/internal/conf/load.go
@@ -47,6 +47,8 @@ func loadFromPath(path string, args args.Config) (*globalConfig, error) {
 	// A few vars support env var expansion for convenience
 	out.GwCertRaw = os.ExpandEnv(out.GwCertRaw)
 	out.GwKeyRaw = os.ExpandEnv(out.GwKeyRaw)
+	out.GwURLRaw = os.ExpandEnv(out.GwURLRaw)
+	out.GwEnvRaw = os.ExpandEnv(out.GwEnvRaw)
 
 	// Fill in the Environment parent references
 	prefs := map[string]bool{}


### PR DESCRIPTION
Previously, only GwCert and GwKey supported env var expansion. This
commit adds env var expansion support for the GwEnv and GwURL vars.