### PR TITLE
Refactor container build to support pinned base image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+  "enabled": true,
+  "enabledManagers": ["dockerfile", "github-actions"],
+  "dockerfile": {
+    "fileMatch": [".*Containerfile$"]
+  },
+  "automerge": true,
+  "stabilityDays": 3
+}

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ fmt-cmd = if ! test -z $$($(1) | tee /dev/stderr); then echo $(2); exit 3; fi
 BUILDVERSION := $$(git describe HEAD)
 BUILDFLAGS := -ldflags "-X github.com/release-engineering/exodus-rsync/internal/cmd.version=$(BUILDVERSION)"
 
-# Image used for recipes building in a container.
-GOTOOLSET_IMAGE := registry.access.redhat.com/ubi8/go-toolset:latest
-
 # Build the main binary for this project.
 exodus-rsync: generate
 	go build $(BUILDFLAGS) ./cmd/exodus-rsync
@@ -54,8 +51,8 @@ clean:
 # If you have a working 'podman', this can be used as an alternative
 # to installing the go toolchain on the host.
 podman-exodus-rsync:
-	podman pull $(GOTOOLSET_IMAGE)
-	podman run --security-opt label=disable -v $$PWD:/src $(GOTOOLSET_IMAGE) make -C /src
+	podman build -t exodus-rsync-build -f build.Containerfile .
+	podman run --security-opt label=disable -v $$PWD:/src exodus-rsync-build make -C /src
 
 # Target for all checks applied in CI.
 all: exodus-rsync check lint fmt imports symver-check

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -1,0 +1,6 @@
+# An image which may be used for building exodus-rsync.
+#
+# This Containerfile is intentionally left blank (other than the
+# FROM statement). The point is only to pin a certain version of
+# a base image, in a manner which may be updated by renovatebot.
+FROM registry.access.redhat.com/ubi8/go-toolset@sha256:8bdcfa606506e1343fcda2777b7171da9d59c9537396a2454b7e9dc1e855be3e


### PR DESCRIPTION
A minor refactor of the recently introduced makefile recipe for
building in a container. Instead of always pulling the latest image,
let's use a Containerfile to pin to a specific image version, and
have renovatebot update it regularly. This helps ensure a
reproducible build.