### PR TITLE
Exclude same files as legacy CDN from syncs [RHELDST-12185]

### DIFF
--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -119,6 +119,8 @@ func (c *Config) processFilterArgs(rule string, slice []string) []string {
 
 // Excluded exctracts the pattern from Filter arguments and appends it onto Exclude.
 func (c *Config) Excluded() []string {
+	// Automatically exclude certain files we don't want to sync.
+	c.Exclude = append(c.Exclude, ".nfs*", ".latest_rsync", ".lock")
 	return c.processFilterArgs("-", c.Exclude)
 }
 

--- a/internal/args/parse_test.go
+++ b/internal/args/parse_test.go
@@ -185,3 +185,12 @@ func TestStringMapDecodeError(t *testing.T) {
 		t.Fatalf("didn't get expected error, got %s", err.Error())
 	}
 }
+
+func TestAutoExcludedFiles(t *testing.T) {
+	want := []string{".nfs*", ".latest_rsync", ".lock"}
+	c := Config{Src: ".", Dest: "/test-dest"}
+	if got := c.Excluded(); !reflect.DeepEqual(got, want) {
+		t.Errorf("Config.Excluded() = %v, want %v", got, want)
+	}
+
+}

--- a/test/data/srctrees/just-files/.lock
+++ b/test/data/srctrees/just-files/.lock
@@ -1,0 +1,2 @@
+Hi, I'm a lock file!
+You don't want me included in any syncs 'cause I'm ephemeral.


### PR DESCRIPTION
This change simply adds ".nfs*", ".latest_rsync", and ".lock" files
to the exclude argument list to maintain parity with legacy CDN
behavior.