### PR TITLE
Prevent invoking self [RHELDST-12105]

### DIFF
--- a/internal/cmd/cmd_sync_mixed_test.go
+++ b/internal/cmd/cmd_sync_mixed_test.go
@@ -19,11 +19,16 @@ import (
 type fakeRsync struct {
 	delegate rsync.Interface
 	prefix   []string
+	err      error
 }
 
-func (r *fakeRsync) Command(ctx context.Context, args []string) *exec.Cmd {
-	cmd := r.delegate.Command(ctx, args)
+func (r *fakeRsync) Command(ctx context.Context, args []string) (*exec.Cmd, error) {
+	if r.err != nil {
+		// Immediately return the error provided.
+		return nil, r.err
+	}
 
+	cmd, err := r.delegate.Command(ctx, args)
 	cmd.Path = r.prefix[0]
 	cmd.Args = append(r.prefix, cmd.Args...)
 
@@ -35,7 +40,7 @@ func (r *fakeRsync) Command(ctx context.Context, args []string) *exec.Cmd {
 		cmd.Path = newPath
 	}
 
-	return cmd
+	return cmd, err
 }
 
 func (r *fakeRsync) Exec(ctx context.Context, args args.Config) error {

--- a/internal/cmd/mixed.go
+++ b/internal/cmd/mixed.go
@@ -18,6 +18,12 @@ import (
 func mixedMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 	logger := log.FromContext(ctx)
 
+	rsyncCmd, err := ext.rsync.Command(ctx, rsync.Arguments(ctx, args))
+	if err != nil {
+		logger.F("error", err).Error("Failed to generate rsync command")
+		return 25
+	}
+
 	ctx, cancelFn := context.WithCancel(ctx)
 
 	wg := sync.WaitGroup{}
@@ -51,7 +57,6 @@ func mixedMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 	var lastCode *chan int
 	rsyncCode := make(chan int, 1)
 	exodusCode := make(chan int, 1)
-	rsyncCmd := ext.rsync.Command(ctx, rsync.Arguments(ctx, args))
 
 	// Let rsync & exodus publishes run in their own goroutines.
 	go func() {

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -119,7 +119,12 @@ func logCommand(ctx context.Context, cfg conf.Config, args args.Config) {
 	logger.F("src", args.Src, "dest", args.Dest, "prefix", prefix,
 		"strip", strip).Warn("paths")
 
-	cmd := ext.rsync.Command(ctx, rsync.Arguments(ctx, args))
+	cmd, err := ext.rsync.Command(ctx, rsync.Arguments(ctx, args))
+	if err != nil {
+		logger.F("error", err).Error("Couldn't generate rysnc command")
+		return
+	}
+
 	logger.F("mode", cfg.RsyncMode(), "path", cmd.Path, "args", cmd.Args).Warn("rsync")
 }
 

--- a/internal/rsync/mock.go
+++ b/internal/rsync/mock.go
@@ -37,11 +37,12 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Command mocks base method.
-func (m *MockInterface) Command(arg0 context.Context, arg1 []string) *exec.Cmd {
+func (m *MockInterface) Command(arg0 context.Context, arg1 []string) (*exec.Cmd, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Command", arg0, arg1)
 	ret0, _ := ret[0].(*exec.Cmd)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Command indicates an expected call of Command.


### PR DESCRIPTION
Previously, when the rsync command was missing from the system,
exodus-rsync would find and call itself in a loop.
This commit adds an additional check to prevent exodus-rsync from
detecting itself as real rsync.