### PR TITLE
Add content-type to publish items [RHELDST-12078]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/apex/log v1.9.0
 	github.com/aws/aws-sdk-go v1.44.42
 	github.com/coreos/go-systemd/v22 v22.3.2
+	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.7.5
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gabriel-vasile/mimetype v1.4.0 h1:Cn9dkdYsMIu56tGho+fqzh7XmvY2YyGU0FnbhiOsEro=
+github.com/gabriel-vasile/mimetype v1.4.0/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
@@ -85,6 +87,7 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -96,6 +99,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -106,6 +110,7 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/cmd/exodus.go
+++ b/internal/cmd/exodus.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/release-engineering/exodus-rsync/internal/args"
 	"github.com/release-engineering/exodus-rsync/internal/conf"
 	"github.com/release-engineering/exodus-rsync/internal/gw"
@@ -177,6 +178,17 @@ func exodusMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 
 	for _, item := range items {
 		gwItem := gw.ItemInput{WebURI: webURI(item.SrcPath, args.Src, destTree, srcIsDir)}
+
+		// Try to detect MIME type of file.
+		// mimetype will return "application/octet-stream" type if it
+		// can't make a determination or encounters an error.
+		mtype, err := mimetype.DetectFile(item.SrcPath)
+		logger.F(
+			"file", item.SrcPath,
+			"MIME type", mtype.String(),
+			"error", err,
+		).Debug("MIME type detection attempted")
+		gwItem.ContentType = mtype.String()
 
 		if item.LinkTo != "" {
 			linkSrcDirRelative := path.Dir(getRelPath(item.SrcPath, args.Src))

--- a/internal/gw/client_publish_errors_test.go
+++ b/internal/gw/client_publish_errors_test.go
@@ -146,7 +146,7 @@ func TestClientPublishErrors(t *testing.T) {
 			)),
 		}
 
-		err := publish.AddItems(ctx, []ItemInput{{"/some/uri", "abc123", ""}})
+		err := publish.AddItems(ctx, []ItemInput{{"/some/uri", "abc123", "mime/type", ""}})
 
 		if err == nil {
 			t.Error("Unexpectedly failed to return an error")

--- a/internal/gw/client_publish_test.go
+++ b/internal/gw/client_publish_test.go
@@ -38,8 +38,8 @@ func TestClientPublish(t *testing.T) {
 
 	// It should be able to add some items
 	addItems := []ItemInput{
-		{"/some/path", "1234", ""},
-		{"/other/path", "223344", ""},
+		{"/some/path", "1234", "mime/type", ""},
+		{"/other/path", "223344", "mime/type", ""},
 	}
 	err = publish.AddItems(ctx, addItems)
 	if err != nil {
@@ -99,8 +99,8 @@ func TestClientGetPublish(t *testing.T) {
 
 	// It should be able to add some items
 	addItems := []ItemInput{
-		{"/some/path", "1234", ""},
-		{"/other/path", "223344", ""},
+		{"/some/path", "1234", "mime/type", ""},
+		{"/other/path", "223344", "mime/type", ""},
 	}
 	err = p.AddItems(ctx, addItems)
 	if err != nil {

--- a/internal/gw/gw_helpers_test.go
+++ b/internal/gw/gw_helpers_test.go
@@ -170,7 +170,7 @@ func (f *fakeGw) addPublishItems(r *http.Request, id string) *http.Response {
 	}
 
 	for _, item := range requestItems {
-		publish.items = append(publish.items, ItemInput{item["web_uri"], item["object_key"], item["link_to"]})
+		publish.items = append(publish.items, ItemInput{item["web_uri"], item["object_key"], item["content_type"], item["link_to"]})
 	}
 
 	out.Status = "200 OK"

--- a/internal/gw/publish.go
+++ b/internal/gw/publish.go
@@ -19,9 +19,10 @@ type publish struct {
 
 // ItemInput is a single item accepted for publish by the AddItems method.
 type ItemInput struct {
-	WebURI    string `json:"web_uri"`
-	ObjectKey string `json:"object_key"`
-	LinkTo    string `json:"link_to"`
+	WebURI      string `json:"web_uri"`
+	ObjectKey   string `json:"object_key"`
+	ContentType string `json:"content_type"`
+	LinkTo      string `json:"link_to"`
 }
 
 // NewPublish creates and returns a new publish object within exodus-gw.


### PR DESCRIPTION
This commit adds the content-type to InputItems, using
github.com/gabriel-vasile/mimetype to attempt discovery based on the
item's src path, defaulting it "application/octet-stream".