### PR TITLE
Make logging ASCII-safe [RHELDST-12595]

### DIFF
--- a/internal/log/base_handler.go
+++ b/internal/log/base_handler.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	apexLog "github.com/apex/log"
+)
+
+var stringMap = [...]string{
+	apexLog.DebugLevel: "DEBUG",
+	apexLog.InfoLevel:  "INFO",
+	apexLog.WarnLevel:  "WARN",
+	apexLog.ErrorLevel: "ERROR",
+	apexLog.FatalLevel: "FATAL",
+}
+
+type baseHandler struct {
+	mu     sync.Mutex
+	Writer io.Writer
+}
+
+func newBaseHandler(w io.Writer) *baseHandler {
+	return &baseHandler{
+		Writer: w,
+	}
+}
+
+func (h *baseHandler) HandleLog(e *apexLog.Entry) error {
+	level := stringMap[e.Level]
+	names := e.Fields.Names()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	fmt.Fprintf(h.Writer, "%s: %-25s", level, e.Message)
+
+	for _, name := range names {
+		fmt.Fprintf(h.Writer, " %s=%v", name, e.Fields.Get(name))
+	}
+
+	fmt.Fprintln(h.Writer)
+
+	return nil
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	apexLog "github.com/apex/log"
-	"github.com/apex/log/handlers/cli"
 	"github.com/apex/log/handlers/level"
 	"github.com/apex/log/handlers/multi"
 	"github.com/coreos/go-systemd/v22/journal"
@@ -100,17 +99,14 @@ func (l *Logger) F(v ...interface{}) *apexLog.Entry {
 func (impl) NewLogger(args args.Config) *Logger {
 	logger := Logger{}
 
-	cliLevel := WarnLevel
+	logLevel := WarnLevel
 	if args.Verbose == 1 {
-		cliLevel = InfoLevel
+		logLevel = InfoLevel
 	} else if args.Verbose >= 2 {
-		cliLevel = DebugLevel
+		logLevel = DebugLevel
 	}
 
-	logger.Handler = level.New(
-		cli.New(os.Stdout),
-		cliLevel,
-	)
+	logger.Handler = level.New(newBaseHandler(os.Stdout), logLevel)
 
 	return &logger
 }


### PR DESCRIPTION
This commit implements a new base logging handler outputting plain-text.
This handler replaces the Apex log 'cli' handler which used non-ASCII
characters.