### PR TITLE
Add a missing entry to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 1.9.1 - 2022-08-02
 
 - Fix: exodus-rsync cannot publish with links error
+- Uploads are now parallelized; introduced `uploadthreads` config option
 
 ## 1.9.0 - 2022-07-28
 


### PR DESCRIPTION
exodus-rsync 1.9.1 started to respect the 'uploadthreads' option, but this was not mentioned in the changelog.