### PR TITLE
Refactor upload to parallelize existence checks [RHELDST-13868]

### DIFF
--- a/internal/gw/client.go
+++ b/internal/gw/client.go
@@ -147,7 +147,17 @@ func (c *client) uploadBlob(ctx context.Context, item walk.SyncItem) error {
 	return nil
 }
 
+type uploadState int
+
+const (
+	uploaded  = iota // uploaded successfully
+	present          // skipped because already present
+	duplicate        // skipped because it's handled by another item in the same publish
+	failed           // tried to upload and failed
+)
+
 type uploadResult struct {
+	State uploadState
 	Error error
 	Item  walk.SyncItem
 }
@@ -159,15 +169,80 @@ func (c *client) uploadWorker(
 	wg *sync.WaitGroup,
 	workerID int,
 ) {
+	defer wg.Done()
+
 	for item := range items {
+		// Determine if the blob is already present in the bucket
+		have, err := c.haveBlob(ctx, item)
+		if err != nil {
+			results <- uploadResult{
+				failed,
+				fmt.Errorf("checking for presence of %s: %w", item.Key, err),
+				item}
+			return
+		}
+
+		// If so, no need to upload it
+		if have {
+			results <- uploadResult{present, nil, item}
+			continue
+		}
+
 		if err := c.uploadBlob(ctx, item); err != nil {
-			results <- uploadResult{err, item}
+			results <- uploadResult{failed, err, item}
 			break
 		}
-		results <- uploadResult{nil, item}
+
+		results <- uploadResult{uploaded, nil, item}
 		log.FromContext(ctx).F("worker", workerID, "goroutines", runtime.NumGoroutine(), "key", item.Key).Debug("upload thread")
 	}
-	wg.Done()
+}
+
+func readUploadResults(
+	out chan<- error,
+	cancelFn func(),
+	results <-chan uploadResult,
+	onUploaded func(walk.SyncItem) error,
+	onPresent func(walk.SyncItem) error,
+	onDuplicate func(walk.SyncItem) error,
+) {
+	writtenOut := false
+	sendError := func(err error) {
+		if !writtenOut {
+			out <- err
+			writtenOut = true
+		}
+	}
+
+	defer close(out)
+	defer sendError(nil)
+
+	for result := range results {
+		if result.State == failed {
+			sendError(result.Error)
+			cancelFn()
+		}
+
+		callback := func(walk.SyncItem) error {
+			return nil
+		}
+
+		switch result.State {
+		case present:
+			callback = onPresent
+		case duplicate:
+			callback = onDuplicate
+		case uploaded:
+			callback = onUploaded
+		}
+
+		callbackErr := callback(result.Item)
+
+		if callbackErr != nil {
+			sendError(callbackErr)
+			cancelFn()
+		}
+	}
 }
 
 func (c *client) EnsureUploaded(
@@ -179,64 +254,67 @@ func (c *client) EnsureUploaded(
 ) error {
 	// Maintain a map of items processed thus far
 	processedItems := make(map[string]walk.SyncItem)
-	// The final collection of items to upload
 
 	numThreads := c.cfg.UploadThreads()
 	var wg sync.WaitGroup
 	results := make(chan uploadResult, len(items))
 	jobs := make(chan walk.SyncItem, len(items))
 
+	// Make a child context so we can cancel all uploads at once if an error occurs
+	// in any of them.
+	uploadCtx, uploadCancel := context.WithCancel(ctx)
+
+	// These goroutines are responsible for handling each item by reading
+	// from 'jobs' and writing a result per item to 'results'.
 	for i := 0; i < numThreads; i++ {
 		wg.Add(1)
-		go c.uploadWorker(ctx, jobs, results, &wg, i+1)
+		go c.uploadWorker(uploadCtx, jobs, results, &wg, i+1)
 	}
 
+	// This goroutine is responsible for reading all the results as they come into
+	// 'results' channel and executing callbacks as needed, as well as calculating
+	// the final error state.
+	//
+	// Ensures that callbacks are invoked as quickly as possible, but only
+	// from a single goroutine.
+	out := make(chan error, 1)
+	go readUploadResults(
+		out, uploadCancel, results,
+		onUploaded, onPresent, onDuplicate)
+
+	// Now send all the items
 	for _, item := range items {
 		if item.Key == "" && item.LinkTo != "" {
 			log.FromContext(ctx).F("uri", item.SrcPath).Debug("Skipping unfollowed symlink")
 			continue
 		}
 
-		// Determine if the blob is already present in the bucket
-		have, err := c.haveBlob(ctx, item)
-		if err != nil {
-			return fmt.Errorf("checking for presence of %s: %w", item.Key, err)
-		}
-		// If so, do not include it in the final set of items to upload
-		if have {
-			if err = onPresent(item); err != nil {
-				return err
-			}
+		// Determine if the item already exists in the final set of items to upload
+		// If so, ensure we put it on the queue only once
+		if _, ok := processedItems[item.Key]; ok {
+			log.FromContext(ctx).F("uri", item.SrcPath).Debug("Skipping duplicate item")
+			// This can bypass 'jobs' completely and go straight to 'results' as we
+			// know there's nothing to be done.
+			results <- uploadResult{duplicate, nil, item}
 			continue
 		}
 
-		// Determine if the item already exists in the final set of items to upload
-		// If so, prevent a costly re-upload of the item
-		if _, ok := processedItems[item.Key]; ok {
-			log.FromContext(ctx).F("uri", item.SrcPath).Debug("Skipping duplicate item")
-			if err := onDuplicate(item); err != nil {
-				return err
-			}
-			continue
-		}
 		processedItems[item.Key] = item
 		jobs <- item
 	}
+
+	// Let the uploaders know there are no more items to process.
 	close(jobs)
-	// Wait for all goroutines to complete
+
+	// Wait for uploaders to complete.
 	wg.Wait()
+
+	// Let the results reader know there are no more results coming.
 	close(results)
-	// Check for errors
-	for result := range results {
-		if result.Error != nil {
-			return result.Error
-		}
-		err := onUploaded(result.Item)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+
+	// Block for the result reader to complete and return whatever
+	// error (or nil) it calculated.
+	return <-out
 }
 
 func (impl) NewClient(ctx context.Context, cfg conf.Config) (Client, error) {


### PR DESCRIPTION
Commit 91a0db4b2b8345a introduced goroutines to the upload process so that multiple files could be uploaded at once.

However, the part of the process checking whether a file already exists in the bucket was still not parallelized. According to testing as seen in RHELDST-13868, for a large push it is possible even for the existence checks to take several hours, so it makes sense to support parallelizing this as well.

This commit refactors the upload step so the existence checks also happen concurrently. In local testing with default config this reduces the time taken to check 1000 blobs from 60 to 15 seconds.

Making the existence checks concurrent is the primary motivation of this refactor, but it is also improved in two other ways:

- callbacks are now all invoked as the uploads are still ongoing. Previously the onUploaded callback would only be invoked after *all* uploads had already completed, which would make it of limited use for reporting progress (possibly impacting RHELDST-13869).

- uploads are now cancelled as soon as a single error occurs, rather than continuing to process all other items even after we already know we're going to fail.

The refactored code remains 100% covered by existing tests.