### PR TITLE
Increase log verbosity at the 'info' level [RHELDST-13869]

### DIFF
--- a/internal/cmd/exodus.go
+++ b/internal/cmd/exodus.go
@@ -106,6 +106,7 @@ func exodusMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 	}
 	srcIsDir := fileStat.IsDir()
 
+	logger.Info("Walking directory tree")
 	err = walk.Walk(ctx, args, onlyThese, func(item walk.SyncItem) error {
 		if args.IgnoreExisting {
 			// This argument is not (properly) supported, so bail out.
@@ -135,6 +136,8 @@ func exodusMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 		return 73
 	}
 
+	logger.F("items", len(items)).Info("Preparing to upload items")
+
 	uploadCount := 0
 	existingCount := 0
 	duplicateCount := 0
@@ -162,6 +165,8 @@ func exodusMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 	logger.F("uploaded", uploadCount, "existing", existingCount, "duplicate", duplicateCount).Info("Completed uploads")
 
 	var publish gw.Publish
+
+	logger.F("items", len(items)).Info("Preparing to publish items")
 
 	if args.Publish == "" {
 		// No publish provided, then create a new one.
@@ -216,6 +221,7 @@ func exodusMain(ctx context.Context, cfg conf.Config, args args.Config) int {
 
 	if args.Publish == "" {
 		// We created the publish, then we should commit it.
+		logger.F("publish", publish.ID()).Info("Preparing to commit publish")
 		err = publish.Commit(ctx)
 		if err != nil {
 			logger.F("error", err).Error("can't commit publish")

--- a/internal/gw/client.go
+++ b/internal/gw/client.go
@@ -97,7 +97,7 @@ func (c *client) haveBlob(ctx context.Context, item walk.SyncItem) (bool, error)
 	})
 
 	if err == nil {
-		logger.F("key", item.Key).Debug("blob is present")
+		logger.F("key", item.Key).Info("Skipping upload, blob is present")
 		return true, nil
 	}
 

--- a/internal/gw/publish.go
+++ b/internal/gw/publish.go
@@ -3,6 +3,7 @@ package gw
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/release-engineering/exodus-rsync/internal/log"
 )
@@ -94,12 +95,15 @@ func (p *publish) AddItems(ctx context.Context, items []ItemInput) error {
 
 	count := 0
 	empty := struct{}{}
+	totalBatches := math.Ceil(float64(len(items)) / float64(batchSize))
 
 	for nextBatch(); len(batch) > 0; nextBatch() {
 		count++
+		// Log the current batch number at Info to serve as a gradual progress indicator.
+		logger.F("currentBatch", count, "totalBatches", totalBatches).Info("Preparing the next batch of items")
 
 		for _, item := range batch {
-			logger.F("item", item, "batch", count, "url", url).Debug("Adding to publish object")
+			logger.F("item", item, "url", url).Debug("Adding to publish object")
 		}
 
 		err := c.doJSONRequest(ctx, "PUT", url, batch, &empty)

--- a/internal/walk/walk.go
+++ b/internal/walk/walk.go
@@ -67,6 +67,8 @@ func fillItem(ctx context.Context, c chan<- syncItemPrivate, w walkItem, links b
 	}
 
 	if info.Mode().IsDir() {
+		// Log directories at Info to serve as a gradual progress indicator.
+		logger.F("directory", w.SrcPath).Info("Walking directory")
 		// Nothing to do
 		return nil
 	}


### PR DESCRIPTION
The info level logger (i.e., '-v') lacked adequate progress logging, to the point of appearing stuck. This commit adds some additional logs at the Info level. The intent behind adding these logs is to assure users that exodus-rsync is, in fact, progressing normally.