### PR TITLE
Update to Go 1.19 [RHELDST-14916]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.19
 
     - name: Run all checks
       run: make all

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.19
 
     - name: Compile
       run: make BUILDVERSION=v${{ steps.get_version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- n/a
+- Updated to Go version 1.19
 
 ## 1.9.4 - 2022-11-21
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/release-engineering/exodus-rsync
 
-go 1.16
+go 1.19
 
 require (
 	github.com/adrg/xdg v0.4.0
@@ -12,4 +12,16 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.1
 	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
-github.com/alecthomas/assert/v2 v2.1.0/go.mod h1:b/+1DI2Q6NckYi+3mXyH3wFb8qG37K/DuK80n7WefXA=
 github.com/alecthomas/kong v0.7.1 h1:azoTh0IOfwlAX3qN9sHWTxACE2oV8Bg2gAwBsMwDQY4=
 github.com/alecthomas/kong v0.7.1/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
-github.com/alecthomas/repr v0.1.0/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=
 github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
@@ -33,7 +31,6 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/go.tools.mod
+++ b/go.tools.mod
@@ -1,6 +1,6 @@
 module github.com/release-engineering/exodus-rsync
 
-go 1.16
+go 1.19
 
 require (
 	github.com/golang/mock v1.5.0 // indirect

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -78,16 +78,15 @@ type Logger struct {
 //
 // This code:
 //
-//   logger.F("a", a, "b", b, "c", c).Info(...)
+//	logger.F("a", a, "b", b, "c", c).Info(...)
 //
 // ...is equivalent to the following more cumbersome:
 //
-//   logger.WithField("a", a).WithField("b", b).WithField("c", c).Info(...)
+//	logger.WithField("a", a).WithField("b", b).WithField("c", c).Info(...)
 //
 // ...or:
 //
-//   logger.WithFields(log.Fields{"a", a, "b", b, "c", c}).Info(...)
-//
+//	logger.WithFields(log.Fields{"a", a, "b", b, "c", c}).Info(...)
 func (l *Logger) F(v ...interface{}) *apexLog.Entry {
 	fields := apexLog.Fields{}
 	for i := 0; i < len(v); i += 2 {

--- a/internal/rsync/lookup_test.go
+++ b/internal/rsync/lookup_test.go
@@ -11,18 +11,6 @@ import (
 	"github.com/release-engineering/exodus-rsync/internal/log"
 )
 
-func setPath(t *testing.T, value string) {
-	oldPath := os.Getenv("PATH")
-
-	t.Cleanup(func() {
-		os.Setenv("PATH", oldPath)
-	})
-	err := os.Setenv("PATH", value)
-	if err != nil {
-		t.Fatalf("could not set PATH, err = %v", err)
-	}
-}
-
 // If an rsync command can't be located, /usr/bin/rsync is used
 // as fallback.
 func TestCommandFallback(t *testing.T) {
@@ -59,7 +47,7 @@ func TestCommandAvoidSelf(t *testing.T) {
 
 	// Add dir containing self to path *and also* test/bin, which contains
 	// the "real" rsync in the context of this test
-	setPath(t, tempDir+":../../test/bin")
+	setPath(t, tempDir+":"+testBinPath(t))
 
 	// Sanity check: naive lookup of rsync should find self
 	foundRsync, err := exec.LookPath("rsync")
@@ -79,7 +67,7 @@ func TestCommandAvoidSelf(t *testing.T) {
 
 	// Rather than looking up ourselves as a plain LookPath did, it should be smart
 	// enough to remove self from path and find the "real" rsync
-	if cmd.Path != "../../test/bin/rsync" {
+	if cmd.Path != testBinPath(t)+"/rsync" {
 		t.Errorf("command returned unexpected path %v", cmd.Path)
 	}
 }


### PR DESCRIPTION
Bump the version of Go used in CI and for building releases from 1.16 to 1.19. The primary motivations are general maintenance, and unblocking some dependabot updates which appear to require Go > 1.16.

One backwards-incompatible change required updates to a few tests: per https://tip.golang.org/doc/go1.19#os-exec-path ,
PATH lookup relative to the current directory is no longer allowed for security reasons. Some tests relied on this, so had to be refactored to use absolute paths instead.

Other changes triggered by the upgrade include:

- in go.mod, indirect deps are now listed in a separate block
- "go fmt" made some minor whitespace changes