### PR TITLE
Do not merge: disable TLS verification for CodeQL testing

### DIFF
--- a/internal/gw/client.go
+++ b/internal/gw/client.go
@@ -327,7 +327,8 @@ func (impl) NewClient(ctx context.Context, cfg conf.Config) (Client, error) {
 
 	transport := http.Transport{
 		TLSClientConfig: &tls.Config{
-			Certificates: []tls.Certificate{cert},
+			Certificates:       []tls.Certificate{cert},
+			InsecureSkipVerify: true,
 		},
 	}
 	out.httpClient = &http.Client{Transport: &transport}


### PR DESCRIPTION
If CodeQL scanning works properly, this should generate a complaint.