### PR TITLE
Revert "Add space on CHANGELOG.md for testing GitHub Actions [RHELDST-15095]"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Updated to Go version 1.19 
+- Updated to Go version 1.19
 
 ## 1.9.4 - 2022-11-21
 


### PR DESCRIPTION
Reverts release-engineering/exodus-rsync#269 for testing https://github.com/release-engineering/exodus-rsync/pull/270 and https://github.com/release-engineering/exodus-rsync/pull/262 