### PR TITLE
Add idempotency header to idempotent requests [RHELDST-15030]

### DIFF
--- a/internal/gw/client.go
+++ b/internal/gw/client.go
@@ -39,7 +39,7 @@ type client struct {
 	dryRun     bool
 }
 
-func (c *client) doJSONRequest(ctx context.Context, method string, url string, body interface{}, target interface{}) error {
+func (c *client) doJSONRequest(ctx context.Context, method string, url string, body interface{}, target interface{}, headers map[string][]string) error {
 	var bodyReader io.Reader
 	if body == nil {
 		bodyReader = nil
@@ -61,6 +61,11 @@ func (c *client) doJSONRequest(ctx context.Context, method string, url string, b
 
 	req.Header["Accept"] = []string{"application/json"}
 	req.Header["Content-Type"] = []string{"application/json"}
+	// Adding provided headers after setting Accept and Content-Type
+	// headers allows caller to overwrite them if necessary.
+	for key, value := range headers {
+		req.Header[key] = value
+	}
 
 	logConnectionOpen(ctx, fullURL)
 	defer logConnectionClose(ctx, fullURL)
@@ -95,7 +100,7 @@ func (c *client) doJSONRequest(ctx context.Context, method string, url string, b
 
 func (c *client) WhoAmI(ctx context.Context) (map[string]interface{}, error) {
 	out := make(map[string]interface{})
-	err := c.doJSONRequest(ctx, "GET", "/whoami", nil, &out)
+	err := c.doJSONRequest(ctx, "GET", "/whoami", nil, &out, nil)
 	return out, err
 }
 

--- a/internal/gw/client_encode_error_test.go
+++ b/internal/gw/client_encode_error_test.go
@@ -15,7 +15,7 @@ func TestClientEncodeError(t *testing.T) {
 	// This could be any unmarshallable object
 	x := func() {}
 
-	err := client.doJSONRequest(context.TODO(), "POST", "https://example.com/", x, nil)
+	err := client.doJSONRequest(context.TODO(), "POST", "https://example.com/", x, nil, nil)
 	if err == nil {
 		t.Error("unexpectedly did not fail")
 	}

--- a/internal/gw/publish.go
+++ b/internal/gw/publish.go
@@ -35,7 +35,8 @@ func (c *client) NewPublish(ctx context.Context) (Publish, error) {
 	url := "/" + c.cfg.GwEnv() + "/publish"
 
 	out := &publish{}
-	if err := c.doJSONRequest(ctx, "POST", url, nil, &out.raw); err != nil {
+	headers := map[string][]string{"X-Idempotency-Key": {}}
+	if err := c.doJSONRequest(ctx, "POST", url, nil, &out.raw, headers); err != nil {
 		return out, err
 	}
 
@@ -106,7 +107,8 @@ func (p *publish) AddItems(ctx context.Context, items []ItemInput) error {
 			logger.F("item", item, "url", url).Debug("Adding to publish object")
 		}
 
-		err := c.doJSONRequest(ctx, "PUT", url, batch, &empty)
+		headers := map[string][]string{"X-Idempotency-Key": {}}
+		err := c.doJSONRequest(ctx, "PUT", url, batch, &empty, headers)
 		if err != nil {
 			return err
 		}
@@ -135,7 +137,8 @@ func (p *publish) Commit(ctx context.Context) error {
 	}
 
 	task := task{}
-	if err := c.doJSONRequest(ctx, "POST", url, nil, &task.raw); err != nil {
+	headers := map[string][]string{"X-Idempotency-Key": {}}
+	if err := c.doJSONRequest(ctx, "POST", url, nil, &task.raw, headers); err != nil {
 		return err
 	}
 

--- a/internal/gw/task.go
+++ b/internal/gw/task.go
@@ -28,7 +28,7 @@ func (t *task) refresh(ctx context.Context) error {
 
 	logger.F("url", url).Debug("polling task")
 
-	return t.client.doJSONRequest(ctx, "GET", url, nil, &t.raw)
+	return t.client.doJSONRequest(ctx, "GET", url, nil, &t.raw, nil)
 }
 
 func (t *task) ID() string {


### PR DESCRIPTION
So that retires are attempted on idempotent exodus-gw requests (Publish's NewPublish, AddItems, and Commit), this commit marks those requests with "X-Idempotency-Key" header.

To facilitate this, a "headers" paramter of type map[string][]string was added to the exodus-gw Client's doJSONRequest method.