### PR TITLE
Fix: incorrect s3 URLs in connection logs [RHELDST-17861]

### DIFF
--- a/internal/gw/client.go
+++ b/internal/gw/client.go
@@ -107,7 +107,7 @@ func (c *client) WhoAmI(ctx context.Context) (map[string]interface{}, error) {
 func (c *client) haveBlob(ctx context.Context, item walk.SyncItem) (bool, error) {
 	logger := log.FromContext(ctx)
 
-	fullURL := c.s3.Endpoint + item.Key
+	fullURL := c.s3.Endpoint + "/" + c.cfg.GwEnv() + "/" + item.Key
 	logConnectionOpen(ctx, fullURL)
 	defer logConnectionClose(ctx, fullURL)
 
@@ -152,7 +152,7 @@ func (c *client) uploadBlob(ctx context.Context, item walk.SyncItem) error {
 	}
 	defer file.Close()
 
-	fullURL := c.s3.Endpoint + item.Key
+	fullURL := c.s3.Endpoint + "/" + c.cfg.GwEnv() + "/" + item.Key
 	logConnectionOpen(ctx, fullURL)
 	defer logConnectionClose(ctx, fullURL)
 


### PR DESCRIPTION
Previously, when logging s3 connections, the logged URL path was missing the environment name and forward slashes.