### PR TITLE
Support different commit modes [RHELDST-20490]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ exodus-aware drop-in replacement for rsync.
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Usage](#usage)
-  - [Differences from rsync](#differences-from-rsync)
-  - [Publish modes](#publish-modes)
-    - [Standalone publish](#standalone-publish)
-    - [Joined publish](#joined-publish)
+    - [Differences from rsync](#differences-from-rsync)
+    - [Publish modes](#publish-modes)
+        - [Standalone publish](#standalone-publish)
+        - [Joined publish](#joined-publish)
 - [License](#license)
 
 <!-- /TOC -->
@@ -86,6 +86,25 @@ gwurl: https://exodus-gw.example.com
 #
 # The exodus-gw environment may be set using an environment variable.
 gwenv: prod
+
+# The commit mode for exodus-gw publish objects, one of the following:
+#
+# "" or "auto" (default):
+#    Commit occurs only if exodus-rsync created the publish (i.e. is operating
+#    in "standalone publish" mode). A phase2 (full) commit will be used.
+#
+# "none":
+#    Commit never occurs, regardless of whether exodus-rsync created
+#    the publish.
+#
+# "phase1", "phase2", <other>...:
+#    A commit of this type occurs, regardless of whether exodus-rsync created
+#    the publish. See exodus-gw documentation for details on the behavior
+#    of each mode:
+#    https://release-engineering.github.io/exodus-gw/api.html#operation/commit_publish__env__publish__publish_id__commit_post
+#
+# The `--exodus-commit=MODE` option overrides this value.
+gwcommit: auto
 
 ###############################################################################
 # Environment configuration
@@ -254,6 +273,7 @@ is a summary of the differences:
   | -------- | ----- |
   | --exodus-conf=PATH | use this configuration file |
   | --exodus-publish=ID | join content to an existing publish (see "Publish modes") |
+  | --exodus-commit=MODE | commit mode for publish (see `gwcommit` in config file) |
   | --exodus-diag | diagnostic mode, outputs various info for troubleshooting |
 
 - exodus-rsync supports only the following rsync arguments, most of which do not have any
@@ -362,9 +382,11 @@ exposed from the CDN or that *none* of them are exposed at all, even if we are i
 in the middle of publishing.  None of the published content becomes visible from the CDN until
 the "commit" operation occurs, which exposes all content at once.
 
+More complex scenarios are possible when specifying a custom commit mode via
+the `gwcommit` config file option or the `--exodus-commit` argument.
 See [the exodus-gw documentation](https://release-engineering.github.io/exodus-gw/api.html#section/Atomicity)
-for more information on the atomicity guarantees when publishing with
-exodus-rsync and exodus-gw.
+for more information on the supported commit modes and the atomicity
+guarantees when publishing with exodus-rsync and exodus-gw.
 
 ## License
 

--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -75,6 +75,8 @@ type ExodusConfig struct {
 
 	Publish string `help:"ID of existing exodus-gw publish to join." validate:"omitempty,uuid"`
 
+	Commit string `help:"Commit publish using this mode" validate:"omitempty,max=20"`
+
 	Diag bool `help:"Diagnostic mode, dumps various information about the environment."`
 }
 

--- a/internal/cmd/cmd_gw_errors_test.go
+++ b/internal/cmd/cmd_gw_errors_test.go
@@ -68,7 +68,7 @@ func setupFailedCommit(ctrl *gomock.Controller, client *gw.MockClient) {
 	publish.EXPECT().AddItems(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Committing fails
-	publish.EXPECT().Commit(gomock.Any()).Return(fmt.Errorf("simulated error"))
+	publish.EXPECT().Commit(gomock.Any(), gomock.Any()).Return(fmt.Errorf("simulated error"))
 }
 
 func setupFailedJoinPublish(ctrl *gomock.Controller, client *gw.MockClient) {

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -40,6 +40,9 @@ type Config interface {
 	// Max number of items to include in a single HTTP request to exodus-gw.
 	GwBatchSize() int
 
+	// Commit mode for publishes.
+	GwCommit() string
+
 	// Execution mode for rsync.
 	RsyncMode() string
 

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -32,6 +32,7 @@ gwurl: $TEST_EXODUS_GW_URL
 gwcert: global-cert
 gwkey: global-key
 gwbatchsize: 100
+gwcommit: abc
 strip: dest:/foo
 
 environments:
@@ -39,6 +40,7 @@ environments:
   gwenv: $TEST_EXODUS_GW_ENV
   gwkey: override-key
   gwpollinterval: 123
+  gwcommit: cba
   rsyncmode: mixed
   strip: dest:/foo/bar
   uploadthreads: 6
@@ -97,6 +99,7 @@ environments:
 	assertEqual("global gwkey", cfg.GwKey(), "global-key")
 	assertEqual("global gwenv", cfg.GwEnv(), "global-env")
 	assertEqual("global gwpollinterval", cfg.GwPollInterval(), 5000)
+	assertEqual("global gwcommit", cfg.GwCommit(), "abc")
 	assertEqual("global rsyncmode", cfg.RsyncMode(), "exodus")
 	assertEqual("global strip", cfg.Strip(), "dest:/foo")
 	assertEqual("global uploadthreads", cfg.UploadThreads(), 4)
@@ -105,6 +108,7 @@ environments:
 	assertEqual("env gwenv", env.GwEnv(), "one-env")
 	assertEqual("env gwkey", env.GwKey(), "override-key")
 	assertEqual("env gwpollinterval", env.GwPollInterval(), 123)
+	assertEqual("env gwcommit", env.GwCommit(), "cba")
 	assertEqual("env rsyncmode", env.RsyncMode(), "mixed")
 	assertEqual("env strip", env.Strip(), "dest:/foo/bar")
 	assertEqual("env uploadthreads", env.UploadThreads(), 6)

--- a/internal/conf/load.go
+++ b/internal/conf/load.go
@@ -46,6 +46,11 @@ func loadFromPath(path string, args args.Config) (*globalConfig, error) {
 	out.GwURLRaw = normalizeURL(os.ExpandEnv(out.GwURLRaw))
 	out.GwEnvRaw = os.ExpandEnv(out.GwEnvRaw)
 
+	// Command-line arg overrides config from file
+	if args.Commit != "" {
+		out.GwCommitRaw = args.Commit
+	}
+
 	// Fill in the Environment parent references
 	prefs := map[string]bool{}
 	for i := range out.EnvironmentsRaw {
@@ -56,6 +61,11 @@ func loadFromPath(path string, args args.Config) (*globalConfig, error) {
 		env.GwKeyRaw = os.ExpandEnv(env.GwKeyRaw)
 		env.GwURLRaw = normalizeURL(os.ExpandEnv(env.GwURLRaw))
 		env.GwEnvRaw = os.ExpandEnv(env.GwEnvRaw)
+
+		// Command-line arg overrides config from file
+		if args.Commit != "" {
+			env.GwCommitRaw = args.Commit
+		}
 
 		if !strings.HasPrefix(env.Prefix(), out.Strip()) {
 			return nil, fmt.Errorf("cannot strip '%s' prefix from '%s'", out.Strip(), env.Prefix())

--- a/internal/conf/mock.go
+++ b/internal/conf/mock.go
@@ -115,6 +115,20 @@ func (mr *MockConfigMockRecorder) GwCert() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwCert", reflect.TypeOf((*MockConfig)(nil).GwCert))
 }
 
+// GwCommit mocks base method.
+func (m *MockConfig) GwCommit() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwCommit")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GwCommit indicates an expected call of GwCommit.
+func (mr *MockConfigMockRecorder) GwCommit() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwCommit", reflect.TypeOf((*MockConfig)(nil).GwCommit))
+}
+
 // GwEnv mocks base method.
 func (m *MockConfig) GwEnv() string {
 	m.ctrl.T.Helper()
@@ -318,6 +332,20 @@ func (m *MockEnvironmentConfig) GwCert() string {
 func (mr *MockEnvironmentConfigMockRecorder) GwCert() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwCert", reflect.TypeOf((*MockEnvironmentConfig)(nil).GwCert))
+}
+
+// GwCommit mocks base method.
+func (m *MockEnvironmentConfig) GwCommit() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwCommit")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GwCommit indicates an expected call of GwCommit.
+func (mr *MockEnvironmentConfigMockRecorder) GwCommit() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwCommit", reflect.TypeOf((*MockEnvironmentConfig)(nil).GwCommit))
 }
 
 // GwEnv mocks base method.
@@ -551,6 +579,20 @@ func (m *MockGlobalConfig) GwCert() string {
 func (mr *MockGlobalConfigMockRecorder) GwCert() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwCert", reflect.TypeOf((*MockGlobalConfig)(nil).GwCert))
+}
+
+// GwCommit mocks base method.
+func (m *MockGlobalConfig) GwCommit() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwCommit")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GwCommit indicates an expected call of GwCommit.
+func (mr *MockGlobalConfigMockRecorder) GwCommit() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwCommit", reflect.TypeOf((*MockGlobalConfig)(nil).GwCommit))
 }
 
 // GwEnv mocks base method.

--- a/internal/conf/structs.go
+++ b/internal/conf/structs.go
@@ -14,6 +14,7 @@ type sharedConfig struct {
 	GwURLRaw          string `yaml:"gwurl"`
 	GwPollIntervalRaw int    `yaml:"gwpollinterval"`
 	GwBatchSizeRaw    int    `yaml:"gwbatchsize"`
+	GwCommitRaw       string `yaml:"gwcommit"`
 	RsyncModeRaw      string `yaml:"rsyncmode"`
 	LogLevelRaw       string `yaml:"loglevel"`
 	LoggerRaw         string `yaml:"logger"`
@@ -71,6 +72,10 @@ func (g *globalConfig) GwPollInterval() int {
 
 func (g *globalConfig) GwBatchSize() int {
 	return nonEmptyInt(g.GwBatchSizeRaw, 10000)
+}
+
+func (g *globalConfig) GwCommit() string {
+	return g.GwCommitRaw
 }
 
 func (g *globalConfig) UploadThreads() int {
@@ -137,6 +142,10 @@ func (e *environment) GwPollInterval() int {
 
 func (e *environment) GwBatchSize() int {
 	return nonEmptyInt(e.GwBatchSizeRaw, e.parent.GwBatchSize())
+}
+
+func (e *environment) GwCommit() string {
+	return nonEmptyString(e.GwCommitRaw, e.parent.GwCommit())
 }
 
 func (e *environment) RsyncMode() string {

--- a/internal/gw/client_dryrun_test.go
+++ b/internal/gw/client_dryrun_test.go
@@ -88,7 +88,7 @@ func TestDryRunPublish(t *testing.T) {
 				t.Errorf("AddItems failed in dry-run mode, err = %v", err)
 			}
 
-			err = p.Commit(ctx)
+			err = p.Commit(ctx, "")
 			if err != nil {
 				t.Errorf("Commit failed in dry-run mode, err = %v", err)
 			}

--- a/internal/gw/client_publish_errors_test.go
+++ b/internal/gw/client_publish_errors_test.go
@@ -123,7 +123,7 @@ func TestClientPublishErrors(t *testing.T) {
 		// Create a publish object directly without filling in any Links.
 		publish := publish{client: clientIface.(*client)}
 
-		err := publish.Commit(ctx)
+		err := publish.Commit(ctx, "")
 
 		if err == nil {
 			t.Error("Unexpectedly failed to return an error")
@@ -177,7 +177,7 @@ func TestClientPublishErrors(t *testing.T) {
 		publish.raw.Links = make(map[string]string)
 		publish.raw.Links["commit"] = "/some/invalid/url"
 
-		err := publish.Commit(ctx)
+		err := publish.Commit(ctx, "")
 
 		if err == nil {
 			t.Error("Unexpectedly failed to return an error")

--- a/internal/gw/client_publish_test.go
+++ b/internal/gw/client_publish_test.go
@@ -56,7 +56,7 @@ func TestClientPublish(t *testing.T) {
 	gw.publishes[publish.ID()].taskStates = []string{"NOT_STARTED", "IN_PROGRESS", "FAILED"}
 
 	// ...then a request to commit should return an error
-	err = publish.Commit(ctx)
+	err = publish.Commit(ctx, "")
 	if err == nil {
 		t.Errorf("unexpectedly failed to get an error from commit")
 	}
@@ -68,9 +68,26 @@ func TestClientPublish(t *testing.T) {
 	gw.publishes[publish.ID()].taskStates = []string{"NOT_STARTED", "IN_PROGRESS", "COMPLETE"}
 
 	// We should be able to commit the result
-	err = publish.Commit(ctx)
+	err = publish.Commit(ctx, "")
 	if err != nil {
 		t.Errorf("unexpected error from commit: %v", err)
+	}
+
+	// And it should have used no specific commit mode
+	if gw.publishes[publish.ID()].lastCommit != "" {
+		t.Errorf("unexpected commit mode: %s", gw.publishes[publish.ID()].lastCommit)
+	}
+
+	// Let's do it again, this time with a non-blank commit mode...
+	gw.publishes[publish.ID()].taskStates = []string{"NOT_STARTED", "IN_PROGRESS", "COMPLETE"}
+	err = publish.Commit(ctx, "xyz")
+	if err != nil {
+		t.Errorf("unexpected error from commit: %v", err)
+	}
+
+	// Our commit mode should have made it into the endpoint
+	if gw.publishes[publish.ID()].lastCommit != "xyz" {
+		t.Errorf("unexpected commit mode: %s", gw.publishes[publish.ID()].lastCommit)
 	}
 }
 

--- a/internal/gw/dryrun.go
+++ b/internal/gw/dryrun.go
@@ -26,6 +26,6 @@ func (*dryRunPublish) AddItems(ctx context.Context, _ []ItemInput) error {
 	return ctx.Err()
 }
 
-func (*dryRunPublish) Commit(ctx context.Context) error {
+func (*dryRunPublish) Commit(ctx context.Context, _ string) error {
 	return ctx.Err()
 }

--- a/internal/gw/gw.go
+++ b/internal/gw/gw.go
@@ -78,7 +78,10 @@ type Publish interface {
 	// The commit operation within exodus-gw is asynchronous. This method will
 	// wait for the commit to complete fully and will return nil only if the
 	// commit has succeeded.
-	Commit(ctx context.Context) error
+	//
+	// 'mode' is the desired commit mode (see exodus-gw docs). It can be empty
+	// to not request any particular mode.
+	Commit(ctx context.Context, mode string) error
 }
 
 // Task represents a single task object within exodus-gw.

--- a/internal/gw/mock.go
+++ b/internal/gw/mock.go
@@ -186,17 +186,17 @@ func (mr *MockPublishMockRecorder) AddItems(arg0, arg1 interface{}) *gomock.Call
 }
 
 // Commit mocks base method.
-func (m *MockPublish) Commit(ctx context.Context) error {
+func (m *MockPublish) Commit(ctx context.Context, mode string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Commit", ctx)
+	ret := m.ctrl.Call(m, "Commit", ctx, mode)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Commit indicates an expected call of Commit.
-func (mr *MockPublishMockRecorder) Commit(ctx interface{}) *gomock.Call {
+func (mr *MockPublishMockRecorder) Commit(ctx, mode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockPublish)(nil).Commit), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockPublish)(nil).Commit), ctx, mode)
 }
 
 // ID mocks base method.

--- a/internal/gw/publish.go
+++ b/internal/gw/publish.go
@@ -129,17 +129,21 @@ func (p *publish) AddItems(ctx context.Context, items []ItemInput) error {
 // The commit operation within exodus-gw is asynchronous. This method will
 // wait for the commit to complete fully and will return nil only if the
 // commit has succeeded.
-func (p *publish) Commit(ctx context.Context) error {
+func (p *publish) Commit(ctx context.Context, mode string) error {
 	var err error
 
 	logger := log.FromContext(ctx)
-	defer logger.F("publish", p.ID()).Trace("Committing publish").Stop(&err)
+	defer logger.F("publish", p.ID(), "mode", mode).Trace("Committing publish").Stop(&err)
 
 	c := p.client
 	url, ok := p.raw.Links["commit"]
 	if !ok {
 		err = fmt.Errorf("publish not eligible for commit: %+v", p.raw)
 		return err
+	}
+
+	if mode != "" {
+		url = url + "?commit_mode=" + mode
 	}
 
 	task := task{}


### PR DESCRIPTION
This adds support to exodus-rsync for using the new commit_mode argument added to the exodus-gw commit API in [1]. The use-case is to allow rhsm-pulp to do a phase1 commit during Pulp publish tasks, to ensure that all RPMs have reached the CDN storage and later fast-forward publishes will work correctly even if the current exodus-gw publish later fails.

The default behavior is not to pass any `commit_mode`, which ensures that exodus-rsync remains compatible with older versions of exodus-gw.

This change is aiming for flexibility:

- the argument's value is intentionally not validated as being "phase1" or "phase2"; validation is left to the server. This avoids exodus-rsync needing further code changes if more commit modes become supported later.

- the mode can be configured both using command-line arguments and the config file. The intent is to use the command-line argument from pubtools-exodus, but it seems wise to also support using the config file for cases not yet anticipated.

[1] https://github.com/release-engineering/exodus-gw/pull/596