### PR TITLE
Implement retries at http RoundTripper level [RHELDST-22079]

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ gwpollinterval: 5000
 # When adding items onto an exodus-gw publish, what is the maximum number of
 # items we'll include in a single HTTP request.
 gwbatchsize: 10000
+
+# How many times to retry failing HTTP requests.
+gwmaxattempts: 3
+
+# Maximum duration (in milliseconds) between retries of HTTP requests.
+gwmaxbackoff: 20000
 ```
 
 In order to publish to exodus CDN it is necessary to configure all of the

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/PuerkitoBio/rehttp v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/PuerkitoBio/rehttp v1.3.0 h1:w54Pb72MQn2eJrSdPsvGqXlAfiK1+NMTGDrOJJ4YvSU=
+github.com/PuerkitoBio/rehttp v1.3.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
@@ -12,12 +14,15 @@ github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3st
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.48.3 h1:btYjT+opVFxUbRz+qSCjJe07cdX82BHmMX/FXYmoL7g=
 github.com/aws/aws-sdk-go v1.48.3/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
@@ -105,6 +110,7 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
 golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -116,6 +122,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -126,6 +133,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -43,6 +43,12 @@ type Config interface {
 	// Commit mode for publishes.
 	GwCommit() string
 
+	// Maximum attempts for any HTTP request to exodus-gw.
+	GwMaxAttempts() int
+
+	// Maximum backoff between retried HTTP requests, in milliseconds.
+	GwMaxBackoff() int
+
 	// Execution mode for rsync.
 	RsyncMode() string
 

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -41,6 +41,8 @@ environments:
   gwkey: override-key
   gwpollinterval: 123
   gwcommit: cba
+  gwmaxattempts: 50
+  gwmaxbackoff: 60
   rsyncmode: mixed
   strip: dest:/foo/bar
   uploadthreads: 6
@@ -100,6 +102,8 @@ environments:
 	assertEqual("global gwenv", cfg.GwEnv(), "global-env")
 	assertEqual("global gwpollinterval", cfg.GwPollInterval(), 5000)
 	assertEqual("global gwcommit", cfg.GwCommit(), "abc")
+	assertEqual("global gwmaxattempts", cfg.GwMaxAttempts(), 3)
+	assertEqual("global gwmaxbackoff", cfg.GwMaxBackoff(), 20000)
 	assertEqual("global rsyncmode", cfg.RsyncMode(), "exodus")
 	assertEqual("global strip", cfg.Strip(), "dest:/foo")
 	assertEqual("global uploadthreads", cfg.UploadThreads(), 4)
@@ -109,6 +113,8 @@ environments:
 	assertEqual("env gwkey", env.GwKey(), "override-key")
 	assertEqual("env gwpollinterval", env.GwPollInterval(), 123)
 	assertEqual("env gwcommit", env.GwCommit(), "cba")
+	assertEqual("env gwmaxattempts", env.GwMaxAttempts(), 50)
+	assertEqual("env gwmaxbackoff", env.GwMaxBackoff(), 60)
 	assertEqual("env rsyncmode", env.RsyncMode(), "mixed")
 	assertEqual("env strip", env.Strip(), "dest:/foo/bar")
 	assertEqual("env uploadthreads", env.UploadThreads(), 6)

--- a/internal/conf/mock.go
+++ b/internal/conf/mock.go
@@ -157,6 +157,34 @@ func (mr *MockConfigMockRecorder) GwKey() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwKey", reflect.TypeOf((*MockConfig)(nil).GwKey))
 }
 
+// GwMaxAttempts mocks base method.
+func (m *MockConfig) GwMaxAttempts() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwMaxAttempts")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwMaxAttempts indicates an expected call of GwMaxAttempts.
+func (mr *MockConfigMockRecorder) GwMaxAttempts() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwMaxAttempts", reflect.TypeOf((*MockConfig)(nil).GwMaxAttempts))
+}
+
+// GwMaxBackoff mocks base method.
+func (m *MockConfig) GwMaxBackoff() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwMaxBackoff")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwMaxBackoff indicates an expected call of GwMaxBackoff.
+func (mr *MockConfigMockRecorder) GwMaxBackoff() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwMaxBackoff", reflect.TypeOf((*MockConfig)(nil).GwMaxBackoff))
+}
+
 // GwPollInterval mocks base method.
 func (m *MockConfig) GwPollInterval() int {
 	m.ctrl.T.Helper()
@@ -374,6 +402,34 @@ func (m *MockEnvironmentConfig) GwKey() string {
 func (mr *MockEnvironmentConfigMockRecorder) GwKey() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwKey", reflect.TypeOf((*MockEnvironmentConfig)(nil).GwKey))
+}
+
+// GwMaxAttempts mocks base method.
+func (m *MockEnvironmentConfig) GwMaxAttempts() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwMaxAttempts")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwMaxAttempts indicates an expected call of GwMaxAttempts.
+func (mr *MockEnvironmentConfigMockRecorder) GwMaxAttempts() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwMaxAttempts", reflect.TypeOf((*MockEnvironmentConfig)(nil).GwMaxAttempts))
+}
+
+// GwMaxBackoff mocks base method.
+func (m *MockEnvironmentConfig) GwMaxBackoff() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwMaxBackoff")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwMaxBackoff indicates an expected call of GwMaxBackoff.
+func (mr *MockEnvironmentConfigMockRecorder) GwMaxBackoff() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwMaxBackoff", reflect.TypeOf((*MockEnvironmentConfig)(nil).GwMaxBackoff))
 }
 
 // GwPollInterval mocks base method.
@@ -621,6 +677,34 @@ func (m *MockGlobalConfig) GwKey() string {
 func (mr *MockGlobalConfigMockRecorder) GwKey() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwKey", reflect.TypeOf((*MockGlobalConfig)(nil).GwKey))
+}
+
+// GwMaxAttempts mocks base method.
+func (m *MockGlobalConfig) GwMaxAttempts() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwMaxAttempts")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwMaxAttempts indicates an expected call of GwMaxAttempts.
+func (mr *MockGlobalConfigMockRecorder) GwMaxAttempts() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwMaxAttempts", reflect.TypeOf((*MockGlobalConfig)(nil).GwMaxAttempts))
+}
+
+// GwMaxBackoff mocks base method.
+func (m *MockGlobalConfig) GwMaxBackoff() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GwMaxBackoff")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GwMaxBackoff indicates an expected call of GwMaxBackoff.
+func (mr *MockGlobalConfigMockRecorder) GwMaxBackoff() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GwMaxBackoff", reflect.TypeOf((*MockGlobalConfig)(nil).GwMaxBackoff))
 }
 
 // GwPollInterval mocks base method.

--- a/internal/conf/structs.go
+++ b/internal/conf/structs.go
@@ -15,6 +15,8 @@ type sharedConfig struct {
 	GwPollIntervalRaw int    `yaml:"gwpollinterval"`
 	GwBatchSizeRaw    int    `yaml:"gwbatchsize"`
 	GwCommitRaw       string `yaml:"gwcommit"`
+	GwMaxAttemptsRaw  int    `yaml:"gwmaxattempts"`
+	GwMaxBackoffRaw   int    `yaml:"gwmaxbackoff"`
 	RsyncModeRaw      string `yaml:"rsyncmode"`
 	LogLevelRaw       string `yaml:"loglevel"`
 	LoggerRaw         string `yaml:"logger"`
@@ -76,6 +78,14 @@ func (g *globalConfig) GwBatchSize() int {
 
 func (g *globalConfig) GwCommit() string {
 	return g.GwCommitRaw
+}
+
+func (g *globalConfig) GwMaxAttempts() int {
+	return nonEmptyInt(g.GwMaxAttemptsRaw, 3)
+}
+
+func (g *globalConfig) GwMaxBackoff() int {
+	return nonEmptyInt(g.GwMaxBackoffRaw, 20000)
 }
 
 func (g *globalConfig) UploadThreads() int {
@@ -146,6 +156,14 @@ func (e *environment) GwBatchSize() int {
 
 func (e *environment) GwCommit() string {
 	return nonEmptyString(e.GwCommitRaw, e.parent.GwCommit())
+}
+
+func (e *environment) GwMaxAttempts() int {
+	return nonEmptyInt(e.GwMaxAttemptsRaw, e.parent.GwMaxAttempts())
+}
+
+func (e *environment) GwMaxBackoff() int {
+	return nonEmptyInt(e.GwMaxBackoffRaw, e.parent.GwMaxBackoff())
 }
 
 func (e *environment) RsyncMode() string {

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -64,6 +64,8 @@ func logConfig(ctx context.Context, cfg conf.Config) {
 		"gwenv", cfg.GwEnv(),
 		"gwpollinterval", cfg.GwPollInterval(),
 		"gwbatchsize", cfg.GwBatchSize(),
+		"gwmaxattempts", cfg.GwMaxAttempts(),
+		"gwmaxbackoff", cfg.GwMaxBackoff(),
 	).Warn("exodus-gw")
 
 	logger.F(

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -24,6 +24,8 @@ func mockConfig(ctrl *gomock.Controller) conf.Config {
 	e.GwEnv().Return("test-env").AnyTimes()
 	e.GwPollInterval().Return(123).AnyTimes()
 	e.GwBatchSize().Return(234).AnyTimes()
+	e.GwMaxAttempts().Return(345).AnyTimes()
+	e.GwMaxBackoff().Return(456).AnyTimes()
 	e.RsyncMode().Return("mixed").AnyTimes()
 	e.LogLevel().Return("debug").AnyTimes()
 	e.Logger().Return("syslog").AnyTimes()

--- a/internal/gw/helpers_test.go
+++ b/internal/gw/helpers_test.go
@@ -36,6 +36,9 @@ func testConfig(t *testing.T) conf.Config {
 	cfg.EXPECT().GwPollInterval().AnyTimes().Return(1)
 	cfg.EXPECT().GwEnv().AnyTimes().Return("env")
 	cfg.EXPECT().GwBatchSize().AnyTimes().Return(3)
+	cfg.EXPECT().GwMaxAttempts().AnyTimes().Return(3)
+	// Fast backoff (1ms) to not slow down tests
+	cfg.EXPECT().GwMaxBackoff().AnyTimes().Return(1)
 	cfg.EXPECT().LogLevel().AnyTimes().Return("info")
 	cfg.EXPECT().Verbosity().AnyTimes().Return(3)
 	cfg.EXPECT().UploadThreads().AnyTimes().Return(4)


### PR DESCRIPTION
While net/http automatically retries on some types of error, it doesn't seem to be enough to cope with certain issues in practice. Add retry logic at the RoundTripper level using a library designed for that.

The retry setup here is close to what the S3 client is already doing internally, so this should cause requests to the gw publish API to be handled more consistently with requests to the upload API.