### PR TITLE
Bump the default value of `gwmaxattempts` [RHELDST-22390]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- n/a
+- Increased default value of `gwmaxattempts`
 
 ## 1.11.0 - 2023-12-04
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ gwpollinterval: 5000
 gwbatchsize: 10000
 
 # How many times to retry failing HTTP requests.
-gwmaxattempts: 3
+gwmaxattempts: 10
 
 # Maximum duration (in milliseconds) between retries of HTTP requests.
 gwmaxbackoff: 20000

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -102,7 +102,7 @@ environments:
 	assertEqual("global gwenv", cfg.GwEnv(), "global-env")
 	assertEqual("global gwpollinterval", cfg.GwPollInterval(), 5000)
 	assertEqual("global gwcommit", cfg.GwCommit(), "abc")
-	assertEqual("global gwmaxattempts", cfg.GwMaxAttempts(), 3)
+	assertEqual("global gwmaxattempts", cfg.GwMaxAttempts(), 10)
 	assertEqual("global gwmaxbackoff", cfg.GwMaxBackoff(), 20000)
 	assertEqual("global rsyncmode", cfg.RsyncMode(), "exodus")
 	assertEqual("global strip", cfg.Strip(), "dest:/foo")

--- a/internal/conf/structs.go
+++ b/internal/conf/structs.go
@@ -81,7 +81,7 @@ func (g *globalConfig) GwCommit() string {
 }
 
 func (g *globalConfig) GwMaxAttempts() int {
-	return nonEmptyInt(g.GwMaxAttemptsRaw, 3)
+	return nonEmptyInt(g.GwMaxAttemptsRaw, 10)
 }
 
 func (g *globalConfig) GwMaxBackoff() int {


### PR DESCRIPTION
Inspired by ticket RHELDST-22390 where a temporary issue in exodus-gw resulted in a push failure. Based on the logs, retries only occurred for a total of ~5 seconds or so which was not enough to recover from the issue. The service did self-heal and an increased retry count probably would have allowed exodus-rsync to ultimately succeed.