### PR TITLE
Fix panic on newer versions of 'validator' library

### DIFF
--- a/internal/args/parse.go
+++ b/internal/args/parse.go
@@ -106,7 +106,7 @@ type Config struct {
 	Dest string `arg:"1" placeholder:"[USER@]HOST:DEST" help:"Remote destination for sync" validate:"max=2000"`
 
 	IgnoredConfig `embed:"1" group:"ignored"`
-	ExodusConfig  `embed:"1" prefix:"exodus-" validate:"dive"`
+	ExodusConfig  `embed:"1" prefix:"exodus-"`
 }
 
 // ValidateConfig enforces constraints defined by the "validate" tag on


### PR DESCRIPTION
The 'dive' tag here was incorrect. Per [1], 'dive' is intended for usage on slices/arrays/maps and not nested structs as we have here. Older versions of validator apparently ignored this, but newer versions detect the mistake with:

    panic: dive error! can't dive on a non slice or map

Note, before making this change I verified that the fields on ExodusConfig are truly being validated; it's not necessary to provide any specific tag to enable the validation of nested structs.

[1] https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Dive