### PR TITLE
S3 client max retires as num of gwmaxattempts from config file

### DIFF
--- a/internal/gw/client.go
+++ b/internal/gw/client.go
@@ -439,6 +439,7 @@ func (impl) NewClient(ctx context.Context, cfg conf.Config) (Client, error) {
 			HTTPClient:       s3HttpClient,
 			Logger:           log.FromContext(ctx),
 			LogLevel:         aws.LogLevel(awsLogLevel),
+			MaxRetries:       aws.Int(cfg.GwMaxAttempts()),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
S3 client retires by default for 3 times rather than applying the retires(gwmaxattempts) defined in the config file. It uses a separate HTTP client than rest of the HTTP requests. So, the config wasn't applicable to the s3 requests.
Hence, this updates the s3 client to apply the retry count defined in the config file for all s3 requests as well.