### PR TITLE
Update to Go 1.23 [RHELDST-26109]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.23
 
     - name: Run all checks
       run: make all

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.23
 
     - name: Compile
       run: make BUILDVERSION=v${{ steps.get_version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- n/a
+- Updated base build image for Go version 1.23
+- Updated to Go version 1.23
 
 ## 1.11.2 - 2024-04-03
 

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -4,5 +4,5 @@
 # FROM statement). The point is only to pin a certain version of
 # a base image, in a manner which may be updated by renovatebot.
 #
-# TODO: use ubi9/go-toolset once that contains golang >= 1.19.
-FROM golang@sha256:04f76f956e51797a44847e066bde1341c01e09054d3878ae88c7f77f09897c4d
+# TODO: use ubi9/go-toolset once that contains golang >= 1.23.
+FROM golang@sha256:45b43371f21ec51276118e6806a22cbb0bca087ddd54c491fdc7149be01035d5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/release-engineering/exodus-rsync
 
-go 1.19
+go 1.23
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -3,9 +3,11 @@ github.com/PuerkitoBio/rehttp v1.4.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWB
 github.com/adrg/xdg v0.5.0 h1:dDaZvhMXatArP1NPHhnfaQUqWBLBsmx1h1HXQdMoFCY=
 github.com/adrg/xdg v0.5.0/go.mod h1:dDdY4M4DF9Rjy4kHPeNL+ilVF+p2lK8IdM9/rTSGcI4=
 github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
+github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v0.9.0 h1:G5diXxc85KvoV2f0ZRVuMsi45IrBgx9zDNGNj165aPA=
 github.com/alecthomas/kong v0.9.0/go.mod h1:Y47y5gKfHp1hDc7CH7OeXgLIpp+Q2m1Ni0L5s3bI8Os=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=
 github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
@@ -33,6 +35,7 @@ github.com/gabriel-vasile/mimetype v1.4.4 h1:QjV6pZ7/XZ7ryI2KuyeEDE8wnh7fHP9YnQy
 github.com/gabriel-vasile/mimetype v1.4.4/go.mod h1:JwLei5XPtWdGiMFB5Pjle1oEeoSeEuJfJE+TtfvdB/s=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -46,6 +49,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/go.tools.mod
+++ b/go.tools.mod
@@ -1,6 +1,6 @@
 module github.com/release-engineering/exodus-rsync
 
-go 1.19
+go 1.23
 
 require (
 	github.com/golang/mock v1.5.0 // indirect


### PR DESCRIPTION
Bump the version of Go used in CI and for building releases from 1.19 to 1.23. This brings us onto the latest stable toolchain - a point of maintenance - and unblocks update of golang.org/x/crypto which requires Go >= 1.20.

Go 1.20 introduced a dynamic linker for glibc in work to make builds deterministically reproducible. Staying glibc-compatible with RHEL 6 now forces use of a Debian 11 platform with older glibc: container image golang:1.23-bullseye and GitHub Runner Ubuntu 20.04.

There's a great [blog](https://go.dev/blog/rebuild) on the mission of making builds deterministically reproducible. As a consequence of that, we get:
```
root@665596e09b07:/go/exodus-rsync# nm -uD exodus-rsync | egrep --only-matching 'pthread_sigmask@GLIBC_2\.[0-9]+' | sort | uniq
pthread_sigmask@GLIBC_2.32
```
... with symver-check on Debian 12 or later systems.

Dropping to a Debian 11 based platform keeps RHEL 6 compatibility. We can only do that until the end of Debian 11 support (EOL 2026-08-31).

An alternative is to set `CGO_ENABLED=0`, if and only if cgo certainly isn’t required.

These seem to be our only options for upgrading Go beyond 1.19.