### PR TITLE
Add tidy command to Makefile generate [RHELDST-31119]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ check: generate
 
 # Run generate.
 generate:
+	go mod tidy
 	go generate ./...
 
 # Run linter.


### PR DESCRIPTION
In github CI, the Makefile's generate macro complains about dependency up-to-dateness. This commit ensures necessary requirements are present in the mod file before installing.